### PR TITLE
Disable editing of begin/end date and duration for summary tasks

### DIFF
--- a/ganttproject/src/net/sourceforge/ganttproject/GanttTreeTableModel.java
+++ b/ganttproject/src/net/sourceforge/ganttproject/GanttTreeTableModel.java
@@ -25,13 +25,16 @@ import biz.ganttproject.core.time.CalendarFactory;
 import biz.ganttproject.core.time.GanttCalendar;
 import biz.ganttproject.core.time.TimeDuration;
 import biz.ganttproject.core.time.impl.GPTimeUnitStack;
+
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;
 import com.google.common.base.Objects;
 import com.google.common.base.Predicate;
+import com.google.common.base.Predicates;
 import com.google.common.base.Supplier;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
+
 import net.sourceforge.ganttproject.gui.UIFacade;
 import net.sourceforge.ganttproject.language.GanttLanguage;
 import net.sourceforge.ganttproject.task.CustomColumnsException;
@@ -42,6 +45,7 @@ import net.sourceforge.ganttproject.task.TaskNode;
 import net.sourceforge.ganttproject.task.TaskProperties;
 import net.sourceforge.ganttproject.task.dependency.TaskDependency;
 import net.sourceforge.ganttproject.task.dependency.TaskDependencyException;
+
 import org.jdesktop.swingx.treetable.DefaultMutableTreeTableNode;
 import org.jdesktop.swingx.treetable.DefaultTreeTableModel;
 
@@ -51,6 +55,7 @@ import javax.swing.event.ChangeEvent;
 import javax.swing.event.ListSelectionEvent;
 import javax.swing.event.TableColumnModelEvent;
 import javax.swing.event.TableColumnModelListener;
+
 import java.math.BigDecimal;
 import java.text.MessageFormat;
 import java.util.Arrays;
@@ -71,14 +76,18 @@ public class GanttTreeTableModel extends DefaultTreeTableModel implements TableC
     static ImageIcon ALERT_TASK_INPROGRESS = new ImageIcon(GanttTreeTableModel.class.getResource("/icons/alert1_16.gif"));
     static ImageIcon ALERT_TASK_OUTDATED = new ImageIcon(GanttTreeTableModel.class.getResource("/icons/alert2_16.gif"));
   }
-
+  static Predicate<Task> NOT_SUPERTASK = new Predicate<Task>() {
+    @Override
+    public boolean apply(Task task) {
+      return !task.isSupertask();
+    }
+  };
   static Predicate<Task> NOT_MILESTONE = new Predicate<Task>() {
     @Override
     public boolean apply(Task input) {
       return !input.isMilestone();
     }
   };
-
   static {
     new DefaultBooleanOption("");
     TaskDefaultColumn.setLocaleApi(new TaskDefaultColumn.LocaleApi() {
@@ -108,8 +117,9 @@ public class GanttTreeTableModel extends DefaultTreeTableModel implements TableC
   public GanttTreeTableModel(
       TaskManager taskManager, CustomPropertyManager customColumnsManager, UIFacade uiFacade, Runnable dirtyfier) {
     super(new TaskNode(taskManager.getRootTask()));
-    TaskDefaultColumn.END_DATE.setIsEditablePredicate(NOT_MILESTONE);
-    TaskDefaultColumn.DURATION.setIsEditablePredicate(NOT_MILESTONE);
+    TaskDefaultColumn.BEGIN_DATE.setIsEditablePredicate(NOT_SUPERTASK);
+    TaskDefaultColumn.END_DATE.setIsEditablePredicate(Predicates.and(NOT_SUPERTASK, NOT_MILESTONE));
+    TaskDefaultColumn.DURATION.setIsEditablePredicate(Predicates.and(NOT_SUPERTASK, NOT_MILESTONE));
     myUiFacade = uiFacade;
     myDirtyfier = dirtyfier;
     myCustomColumnsManager = customColumnsManager;

--- a/ganttproject/src/net/sourceforge/ganttproject/gui/GanttTaskPropertiesBean.java
+++ b/ganttproject/src/net/sourceforge/ganttproject/gui/GanttTaskPropertiesBean.java
@@ -485,6 +485,9 @@ public class GanttTaskPropertiesBean extends JPanel {
     }
     myTaskScheduleDates.setMilestone(isMilestone());
 
+    boolean isSupertask = myUnpluggedClone.getManager().getTaskHierarchy().hasNestedTasks(selectedTasks[0]);
+    myTaskScheduleDates.setSupertask(isSupertask);
+
     tfWebLink.setText(originalWebLink);
 
     if (selectedTasks[0].shapeDefined()) {

--- a/ganttproject/src/net/sourceforge/ganttproject/gui/taskproperties/TaskScheduleDatesPanel.java
+++ b/ganttproject/src/net/sourceforge/ganttproject/gui/taskproperties/TaskScheduleDatesPanel.java
@@ -78,6 +78,7 @@ public class TaskScheduleDatesPanel {
   private final UIFacade myUiFacade;
   private JXHyperlink myLockHyperlink;
   private boolean isMilestone;
+  private JLabel myLockLabel;
 
   public TaskScheduleDatesPanel(UIFacade uiFacade) {
     myUiFacade = uiFacade;
@@ -183,7 +184,8 @@ public class TaskScheduleDatesPanel {
     final GPAction durationLockAction = createLockAction("option.taskProperties.main.scheduling.manual.value.duration", ourDurationLock);
     JComponent durationLabel = createLabel(language.getText("length"), ourDurationLock, durationField1, durationLockAction);
 
-    propertiesPanel.add(new JLabel(language.getText("option.taskProperties.main.scheduling.label")));
+    myLockLabel = new JLabel(language.getText("option.taskProperties.main.scheduling.label"));
+    propertiesPanel.add(myLockLabel);
     final Box box = Box.createHorizontalBox();
     myLockHyperlink = new JXHyperlink(new GPAction("option.taskProperties.main.scheduling.manual.label") {
       @Override
@@ -307,12 +309,30 @@ public class TaskScheduleDatesPanel {
       ourDurationLock.setValue(true);
       ourEndDateLock.setValue(true);
       myLockHyperlink.setEnabled(false);
+      myLockLabel.setEnabled(false);
+    } else {
+      ourDurationLock.setValue(false);
+      ourEndDateLock.setValue(false);
+      myLockHyperlink.setEnabled(true);
+      myLockLabel.setEnabled(true);
+      ourPrevLock.setValue(true);
+    }
+    this.isMilestone = isMilestone;
+  }
+
+  public void setSupertask(boolean isSupertask) {
+    if (isSupertask) {
+      ourStartDateLock.setValue(true);
+      ourDurationLock.setValue(true);
+      ourEndDateLock.setValue(true);
+      myLockHyperlink.setEnabled(false);
+      myLockLabel.setEnabled(false);
     } else {
       ourDurationLock.setValue(false);
       ourEndDateLock.setValue(false);
       myLockHyperlink.setEnabled(true);
       ourPrevLock.setValue(true);
+      myLockLabel.setEnabled(true);
     }
-    this.isMilestone = isMilestone;
   }
 }


### PR DESCRIPTION
The dates of summary tasks are calculated from the dates of child tasks. However, they are editable in the UI which makes false impression that they can be edited. In fact, if user enters some value, it is simply reverted which surprises user.

Update issue #707 