### PR TITLE
Use '-a' operator as 'AND' instead of '&&' in deb/postinst script

### DIFF
--- a/ganttproject-builder/deb/postinst
+++ b/ganttproject-builder/deb/postinst
@@ -8,6 +8,6 @@ if [ "$1" = "configure" ]; then
   if [ -x "$(which update-menus 2>/dev/null)" ]; then update-menus; fi
   if [ -x "$(which update-mime 2>/dev/null)" ]; then update-mime; fi
   if [ -x "$(which update-mime-database 2>/dev/null)" ]; then update-mime-database /usr/share/mime; fi
-  if [ -x "$(which gtk-update-icon-cache 2>/dev/null)" && -d /usr/share/icons/gnome ]; then gtk-update-icon-cache -t -f /usr/share/icons/gnome; fi
+  if [ -x "$(which gtk-update-icon-cache 2>/dev/null)" -a -d /usr/share/icons/gnome ]; then gtk-update-icon-cache -t -f /usr/share/icons/gnome; fi
   if [ -x "$(which xdg-mime 2>/dev/null)" ]; then xdg-mime default ganttproject.desktop application/x-ganttproject; fi
 fi


### PR DESCRIPTION
On installing ganttproject_2.8.3-r2088-1_all.deb, I found an error bellow is shown.
```
/var/lib/dpkg/info/ganttproject.postinst: 11: [: missing ]
```
In `ganttproject.postinst`, an operaotr `&&` is used in `[` command, but it should be `-a`.
