### PR TITLE
Fixes broken "import MS Project and export MS Project" scenario

### DIFF
--- a/biz.ganttproject.impex.msproject2/src/biz/ganttproject/impex/msproject2/CustomPropertyMapping.java
+++ b/biz.ganttproject.impex.msproject2/src/biz/ganttproject/impex/msproject2/CustomPropertyMapping.java
@@ -41,7 +41,7 @@ import java.util.SortedSet;
  * @author dbarashev@bardsoftware.com
  */
 class CustomPropertyMapping {
-  private static final String MSPROJECT_TYPE = "MSPROJECT_TYPE";
+  static final String MSPROJECT_TYPE = "MSPROJECT_TYPE";
 
   static Map<CustomPropertyDefinition, FieldType> buildMapping(TaskManager taskManager) {
     final SortedSet<TaskField> taskFields = Sets.newTreeSet(new Comparator<TaskField>() {

--- a/biz.ganttproject.impex.msproject2/src/biz/ganttproject/impex/msproject2/CustomPropertyMapping.java
+++ b/biz.ganttproject.impex.msproject2/src/biz/ganttproject/impex/msproject2/CustomPropertyMapping.java
@@ -1,0 +1,152 @@
+/*
+Copyright 2017 Dmitry Barashev, BarD Software s.r.o
+
+This file is part of GanttProject, an opensource project management tool.
+
+GanttProject is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+GanttProject is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with GanttProject.  If not, see <http://www.gnu.org/licenses/>.
+*/
+package biz.ganttproject.impex.msproject2;
+
+import com.google.common.base.Function;
+import com.google.common.collect.Sets;
+import net.sf.mpxj.FieldType;
+import net.sf.mpxj.ResourceField;
+import net.sf.mpxj.TaskField;
+import net.sourceforge.ganttproject.CustomPropertyDefinition;
+import net.sourceforge.ganttproject.CustomPropertyManager;
+import net.sourceforge.ganttproject.resource.HumanResourceManager;
+import net.sourceforge.ganttproject.task.TaskManager;
+
+import javax.annotation.Nullable;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.SortedSet;
+
+/**
+ * @author dbarashev@bardsoftware.com
+ */
+class CustomPropertyMapping {
+  private static final String MSPROJECT_TYPE = "MSPROJECT_TYPE";
+
+  static Map<CustomPropertyDefinition, FieldType> buildMapping(TaskManager taskManager) {
+    final SortedSet<TaskField> taskFields = Sets.newTreeSet(new Comparator<TaskField>() {
+      @Override
+      public int compare(TaskField o1, TaskField o2) {
+        return o1.ordinal() - o2.ordinal();
+      }
+    });
+    taskFields.addAll(Arrays.asList(TaskField.values()));
+    return buildMapping(taskManager.getCustomPropertyManager(), taskFields, TaskField.class);
+  }
+
+  static Map<CustomPropertyDefinition, FieldType> buildMapping(HumanResourceManager resourceManager) {
+    final SortedSet<ResourceField> taskFields = Sets.newTreeSet(new Comparator<ResourceField>() {
+      @Override
+      public int compare(ResourceField o1, ResourceField o2) {
+        return o1.ordinal() - o2.ordinal();
+      }
+    });
+    taskFields.addAll(Arrays.asList(ResourceField.values()));
+    return buildMapping(resourceManager.getCustomPropertyManager(), taskFields, ResourceField.class);
+  }
+
+  private static <T extends Enum<T>, S extends FieldType> Map<CustomPropertyDefinition, FieldType> buildMapping(
+      final CustomPropertyManager customPropertyManager,
+      final SortedSet<S> taskFields,
+      final Class<T> enumClass) {
+
+    final Map<CustomPropertyDefinition, FieldType> result = new HashMap<>();
+    class Filter {
+      private LinkedHashSet<CustomPropertyDefinition> allDefs = Sets.newLinkedHashSet(customPropertyManager.getDefinitions());
+      private void run(final Function<CustomPropertyDefinition, String> fxnFieldName) {
+        run0(new Function<CustomPropertyDefinition, S>() {
+          @Override
+          public S apply(@Nullable CustomPropertyDefinition def) {
+            String msProjectType = fxnFieldName.apply(def);
+            return (msProjectType == null) ? null : (S) Enum.valueOf(enumClass, msProjectType);
+          }
+        });
+      }
+      private void run0(Function<CustomPropertyDefinition, S> fxnTaskField) {
+        for (Iterator<CustomPropertyDefinition> it = allDefs.iterator(); it.hasNext(); ) {
+          CustomPropertyDefinition def = it.next();
+            try {
+              FieldType tf = fxnTaskField.apply(def);
+              if (tf != null) {
+                result.put(def, tf);
+                taskFields.remove(tf);
+                it.remove();
+              }
+            } catch (IllegalArgumentException e) {
+              // That's somewhat okay. We have not found such value in the enum, but it might come from the future
+              // versions of MPXJ, so it is not the reason to fail
+            }
+          }
+      }
+    }
+    Filter f = new Filter();
+    // First pass: search for saved MSPROJECT_TYPE attributes.
+    f.run(new Function<CustomPropertyDefinition, String>() {
+      @Override
+      public String apply(@Nullable CustomPropertyDefinition def) {
+        return def.getAttributes().get(MSPROJECT_TYPE);
+      }
+    });
+    // Second pass: find properties with predefined names
+    f.run(new Function<CustomPropertyDefinition, String>() {
+      @Override
+      public String apply(@Nullable CustomPropertyDefinition def) {
+        return def.getName().toUpperCase();
+      }
+    });
+    // Third pass: provide appropriate types for the remaining properties
+    f.run0(new Function<CustomPropertyDefinition, S>() {
+      @Override
+      public S apply(@Nullable CustomPropertyDefinition def) {
+        String name;
+        switch (def.getPropertyClass()) {
+          case BOOLEAN:
+            name = "FLAG";
+            break;
+          case INTEGER:
+          case DOUBLE:
+            name = "NUMBER";
+            break;
+          case TEXT:
+            name = "TEXT";
+            break;
+          case DATE:
+            name = "DATE";
+            break;
+          default:
+            assert false : "Should not be here";
+            name = "TEXT";
+        }
+        S tf1 = (S)Enum.valueOf(enumClass, name + "1");
+        SortedSet<S> tailSet = taskFields.tailSet(tf1);
+        if (tailSet.isEmpty()) {
+          return null;
+        }
+        tf1 = tailSet.first();
+        return (tf1.name().startsWith(name)) ? tf1 : null;
+      }
+    });
+    assert f.allDefs.isEmpty();
+    return result;
+  }
+}

--- a/biz.ganttproject.impex.msproject2/src/biz/ganttproject/impex/msproject2/ProjectFileExporter.java
+++ b/biz.ganttproject.impex.msproject2/src/biz/ganttproject/impex/msproject2/ProjectFileExporter.java
@@ -117,7 +117,7 @@ class ProjectFileExporter {
     }
   }
 
-  private void exportTasks(Map<Integer, net.sf.mpxj.Task> id2mpxjTask) {
+  private void exportTasks(Map<Integer, net.sf.mpxj.Task> id2mpxjTask) throws MPXJException {
 //    Map<CustomPropertyDefinition, FieldType> customProperty_fieldType = new HashMap<CustomPropertyDefinition, FieldType>();
 //    collectCustomProperties(getTaskManager().getCustomPropertyManager(), customProperty_fieldType, TaskField.class);
     Map<CustomPropertyDefinition, FieldType> customProperty_fieldType = CustomPropertyMapping.buildMapping(getTaskManager());
@@ -303,9 +303,6 @@ class ProjectFileExporter {
   }
 
   private void exportResources(Map<Integer, Resource> id2mpxjResource) throws MPXJException {
-//    Map<CustomPropertyDefinition, FieldType> customProperty_fieldType = new HashMap<CustomPropertyDefinition, FieldType>();
-//    collectCustomProperties(getResourceManager().getCustomPropertyManager(), customProperty_fieldType,
-//        ResourceField.class);
     Map<CustomPropertyDefinition, FieldType> customProperty_fieldType = CustomPropertyMapping.buildMapping(getResourceManager());
     for (Entry<CustomPropertyDefinition, FieldType> e : customProperty_fieldType.entrySet()) {
       myOutputProject.getCustomFields().getCustomField(e.getValue()).setAlias(e.getKey().getName());
@@ -336,51 +333,6 @@ class ProjectFileExporter {
       }
     });
     id2mpxjResource.put(hr.getId(), mpxjResource);
-  }
-
-
-  private static <T extends Enum<T>> void collectCustomProperties(CustomPropertyManager customPropertyManager,
-      Map<CustomPropertyDefinition, FieldType> customProperty_fieldType, Class<T> fieldTypeClass) {
-    Map<String, Integer> typeCounter = new HashMap<String, Integer>();
-    for (CustomPropertyDefinition def : customPropertyManager.getDefinitions()) {
-      Integer count = typeCounter.get(def.getTypeAsString());
-      if (count == null) {
-        count = 1;
-      } else {
-        count++;
-      }
-      typeCounter.put(def.getTypeAsString(), count);
-      FieldType ft = getFieldType(fieldTypeClass, def, count);
-      customProperty_fieldType.put(def, ft);
-    }
-  }
-
-  private static <T extends Enum<T>> FieldType getFieldType(Class<T> enumClass, CustomPropertyDefinition def,
-      Integer count) {
-    String name;
-    switch (def.getPropertyClass()) {
-    case BOOLEAN:
-      name = "FLAG";
-      break;
-    case INTEGER:
-    case DOUBLE:
-      name = "NUMBER";
-      break;
-    case TEXT:
-      name = "TEXT";
-      break;
-    case DATE:
-      name = "DATE";
-      break;
-    default:
-      assert false : "Should not be here";
-      name = "TEXT";
-    }
-    try {
-      return (FieldType) Enum.valueOf(enumClass, name + count);
-    } catch (IllegalArgumentException e) {
-      return null;
-    }
   }
 
   private static interface CustomPropertySetter {

--- a/biz.ganttproject.impex.msproject2/src/biz/ganttproject/impex/msproject2/ProjectFileExporter.java
+++ b/biz.ganttproject.impex.msproject2/src/biz/ganttproject/impex/msproject2/ProjectFileExporter.java
@@ -118,8 +118,9 @@ class ProjectFileExporter {
   }
 
   private void exportTasks(Map<Integer, net.sf.mpxj.Task> id2mpxjTask) {
-    Map<CustomPropertyDefinition, FieldType> customProperty_fieldType = new HashMap<CustomPropertyDefinition, FieldType>();
-    collectCustomProperties(getTaskManager().getCustomPropertyManager(), customProperty_fieldType, TaskField.class);
+//    Map<CustomPropertyDefinition, FieldType> customProperty_fieldType = new HashMap<CustomPropertyDefinition, FieldType>();
+//    collectCustomProperties(getTaskManager().getCustomPropertyManager(), customProperty_fieldType, TaskField.class);
+    Map<CustomPropertyDefinition, FieldType> customProperty_fieldType = CustomPropertyMapping.buildMapping(getTaskManager());
     for (Entry<CustomPropertyDefinition, FieldType> e : customProperty_fieldType.entrySet()) {
       myOutputProject.getCustomFields().getCustomField(e.getValue()).setAlias(e.getKey().getName());
     }
@@ -302,9 +303,10 @@ class ProjectFileExporter {
   }
 
   private void exportResources(Map<Integer, Resource> id2mpxjResource) throws MPXJException {
-    Map<CustomPropertyDefinition, FieldType> customProperty_fieldType = new HashMap<CustomPropertyDefinition, FieldType>();
-    collectCustomProperties(getResourceManager().getCustomPropertyManager(), customProperty_fieldType,
-        ResourceField.class);
+//    Map<CustomPropertyDefinition, FieldType> customProperty_fieldType = new HashMap<CustomPropertyDefinition, FieldType>();
+//    collectCustomProperties(getResourceManager().getCustomPropertyManager(), customProperty_fieldType,
+//        ResourceField.class);
+    Map<CustomPropertyDefinition, FieldType> customProperty_fieldType = CustomPropertyMapping.buildMapping(getResourceManager());
     for (Entry<CustomPropertyDefinition, FieldType> e : customProperty_fieldType.entrySet()) {
       myOutputProject.getCustomFields().getCustomField(e.getValue()).setAlias(e.getKey().getName());
     }
@@ -335,6 +337,7 @@ class ProjectFileExporter {
     });
     id2mpxjResource.put(hr.getId(), mpxjResource);
   }
+
 
   private static <T extends Enum<T>> void collectCustomProperties(CustomPropertyManager customPropertyManager,
       Map<CustomPropertyDefinition, FieldType> customProperty_fieldType, Class<T> fieldTypeClass) {

--- a/biz.ganttproject.impex.msproject2/src/biz/ganttproject/impex/msproject2/ProjectFileImporter.java
+++ b/biz.ganttproject.impex.msproject2/src/biz/ganttproject/impex/msproject2/ProjectFileImporter.java
@@ -284,6 +284,7 @@ class ProjectFileImporter {
           name = rf.getName();
         }
         def = myNativeProject.getResourceCustomPropertyManager().createDefinition(typeAsString, name, null);
+        def.getAttributes().put(CustomPropertyMapping.MSPROJECT_TYPE, rf.name());
         myResourceCustomPropertyMapping.put(rf, def);
       }
       nativeResource.setCustomField(def, convertDataValue(rf, r.getCurrentValue(rf)));
@@ -428,6 +429,7 @@ class ProjectFileImporter {
         }
 
         def = myNativeProject.getTaskCustomColumnManager().createDefinition(typeAsString, name, null);
+        def.getAttributes().put(CustomPropertyMapping.MSPROJECT_TYPE, tf.name());
         myTaskCustomPropertyMapping.put(tf, def);
       }
       try {

--- a/ganttproject-tester/build.gradle
+++ b/ganttproject-tester/build.gradle
@@ -4,6 +4,7 @@ dependencies {
   mavenDeps group: 'junit', name: 'junit', version: '4.12'
   testCompile fileTree(dir: project.ext.libDir, include: ['*.jar'])
   testCompile project(':..:ganttproject')
+  testCompile project(':..:biz.ganttproject.impex.msproject2')
 }
 
 updateMavenDeps.doFirst {

--- a/ganttproject-tester/test/biz/ganttproject/impex/msproject2/CustomPropertyMappingTest.java
+++ b/ganttproject-tester/test/biz/ganttproject/impex/msproject2/CustomPropertyMappingTest.java
@@ -1,0 +1,146 @@
+/*
+Copyright 2017 Dmitry Barashev, BarD Software s.r.o
+
+This file is part of GanttProject, an opensource project management tool.
+
+GanttProject is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+GanttProject is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with GanttProject.  If not, see <http://www.gnu.org/licenses/>.
+*/
+package biz.ganttproject.impex.msproject2;
+
+import biz.ganttproject.core.time.GanttCalendar;
+import net.sf.mpxj.FieldType;
+import net.sf.mpxj.MPXJException;
+import net.sf.mpxj.TaskField;
+import net.sourceforge.ganttproject.CustomPropertyDefinition;
+import net.sourceforge.ganttproject.CustomPropertyManager;
+import net.sourceforge.ganttproject.task.TaskManager;
+import net.sourceforge.ganttproject.test.task.TaskTestCase;
+
+import java.util.Map;
+
+/**
+ * Tests mapping of custom properties in GanttProject to TaskField enum values in MPXJ (which become
+ * custom properties in MS Project file)
+ *
+ * @author dbarashev@bardsoftware.com
+ */
+public class CustomPropertyMappingTest extends TaskTestCase {
+  /**
+   * Basic test which maps custom properties from simple project created directly in GP
+   */
+  public void testSimpleTypeMapping() throws MPXJException {
+    TaskManager taskManager = getTaskManager();
+    CustomPropertyDefinition col1 = taskManager.getCustomPropertyManager().createDefinition(
+        CustomPropertyManager.PropertyTypeEncoder.encodeFieldType(String.class), "col1", null);
+    CustomPropertyDefinition col2 = taskManager.getCustomPropertyManager().createDefinition(
+        CustomPropertyManager.PropertyTypeEncoder.encodeFieldType(Boolean.class), "col2", null);
+    CustomPropertyDefinition col3 = taskManager.getCustomPropertyManager().createDefinition(
+        CustomPropertyManager.PropertyTypeEncoder.encodeFieldType(Integer.class), "col3", null);
+    CustomPropertyDefinition col4 = taskManager.getCustomPropertyManager().createDefinition(
+        CustomPropertyManager.PropertyTypeEncoder.encodeFieldType(Double.class), "col4", null);
+    CustomPropertyDefinition col5 = taskManager.getCustomPropertyManager().createDefinition(
+        CustomPropertyManager.PropertyTypeEncoder.encodeFieldType(GanttCalendar.class), "col5", null);
+
+    Map<CustomPropertyDefinition, FieldType> mapping = CustomPropertyMapping.buildMapping(taskManager);
+    assertEquals(TaskField.TEXT1, mapping.get(col1));
+    assertEquals(TaskField.FLAG1, mapping.get(col2));
+    assertEquals(TaskField.NUMBER1, mapping.get(col3));
+    assertEquals(TaskField.NUMBER2, mapping.get(col4));
+    assertEquals(TaskField.DATE1, mapping.get(col5));
+  }
+
+  /**
+   * Tests that custom properties are sequentially mapped to increasing <PROPERTYTYPE>N fields in the order
+   * of their creation in CustomPropertyManager
+   */
+  public void testSequentialNumbers() throws MPXJException {
+    TaskManager taskManager = getTaskManager();
+    CustomPropertyDefinition col5 = taskManager.getCustomPropertyManager().createDefinition(
+        CustomPropertyManager.PropertyTypeEncoder.encodeFieldType(String.class), "col5", null);
+    CustomPropertyDefinition col4 = taskManager.getCustomPropertyManager().createDefinition(
+        CustomPropertyManager.PropertyTypeEncoder.encodeFieldType(String.class), "col4", null);
+    CustomPropertyDefinition col3 = taskManager.getCustomPropertyManager().createDefinition(
+        CustomPropertyManager.PropertyTypeEncoder.encodeFieldType(String.class), "col3", null);
+    CustomPropertyDefinition col2 = taskManager.getCustomPropertyManager().createDefinition(
+        CustomPropertyManager.PropertyTypeEncoder.encodeFieldType(String.class), "col2", null);
+    CustomPropertyDefinition col1 = taskManager.getCustomPropertyManager().createDefinition(
+        CustomPropertyManager.PropertyTypeEncoder.encodeFieldType(String.class), "col1", null);
+
+    Map<CustomPropertyDefinition, FieldType> mapping = CustomPropertyMapping.buildMapping(taskManager);
+    assertEquals(TaskField.TEXT1, mapping.get(col5));
+    assertEquals(TaskField.TEXT2, mapping.get(col4));
+    assertEquals(TaskField.TEXT3, mapping.get(col3));
+    assertEquals(TaskField.TEXT4, mapping.get(col2));
+    assertEquals(TaskField.TEXT5, mapping.get(col1));
+  }
+
+  /**
+   * Tests custom properties with 'special' names. Such names could be created by import from MS Project
+   * in GP < 2.8.5
+   */
+  public void testSpecialNames() throws MPXJException {
+    TaskManager taskManager = getTaskManager();
+    CustomPropertyDefinition col1 = taskManager.getCustomPropertyManager().createDefinition(
+        CustomPropertyManager.PropertyTypeEncoder.encodeFieldType(String.class), "Text1", null);
+    CustomPropertyDefinition col2 = taskManager.getCustomPropertyManager().createDefinition(
+        CustomPropertyManager.PropertyTypeEncoder.encodeFieldType(Boolean.class), "Flag2", null);
+    CustomPropertyDefinition col3 = taskManager.getCustomPropertyManager().createDefinition(
+        CustomPropertyManager.PropertyTypeEncoder.encodeFieldType(Integer.class), "Number3", null);
+    CustomPropertyDefinition col4 = taskManager.getCustomPropertyManager().createDefinition(
+        CustomPropertyManager.PropertyTypeEncoder.encodeFieldType(Double.class), "Number4", null);
+    CustomPropertyDefinition col5 = taskManager.getCustomPropertyManager().createDefinition(
+        CustomPropertyManager.PropertyTypeEncoder.encodeFieldType(GanttCalendar.class), "Date5", null);
+    CustomPropertyDefinition col6 = taskManager.getCustomPropertyManager().createDefinition(
+        CustomPropertyManager.PropertyTypeEncoder.encodeFieldType(Integer.class), "Cost6", null);
+
+    Map<CustomPropertyDefinition, FieldType> mapping = CustomPropertyMapping.buildMapping(taskManager);
+    assertEquals(TaskField.TEXT1, mapping.get(col1));
+    assertEquals(TaskField.FLAG2, mapping.get(col2));
+    assertEquals(TaskField.NUMBER3, mapping.get(col3));
+    assertEquals(TaskField.NUMBER4, mapping.get(col4));
+    assertEquals(TaskField.DATE5, mapping.get(col5));
+    assertEquals(TaskField.COST6, mapping.get(col6));
+  }
+
+  /**
+   * Tests mapping of custom properties with special attribute which is created by import from MS Project
+   * in GP >= 2.8.5
+   */
+  public void testMsProjectType() throws MPXJException {
+    TaskManager taskManager = getTaskManager();
+    CustomPropertyDefinition col5 = taskManager.getCustomPropertyManager().createDefinition(
+        CustomPropertyManager.PropertyTypeEncoder.encodeFieldType(Integer.class), "col5", null);
+    col5.getAttributes().put(CustomPropertyMapping.MSPROJECT_TYPE, "NUMBER1");
+
+    CustomPropertyDefinition col4 = taskManager.getCustomPropertyManager().createDefinition(
+        CustomPropertyManager.PropertyTypeEncoder.encodeFieldType(Integer.class), "col4", null);
+
+    CustomPropertyDefinition col3 = taskManager.getCustomPropertyManager().createDefinition(
+        CustomPropertyManager.PropertyTypeEncoder.encodeFieldType(Integer.class), "col3", null);
+    col3.getAttributes().put(CustomPropertyMapping.MSPROJECT_TYPE, "COST10");
+
+    CustomPropertyDefinition col2 = taskManager.getCustomPropertyManager().createDefinition(
+        CustomPropertyManager.PropertyTypeEncoder.encodeFieldType(Integer.class), "col2", null);
+    CustomPropertyDefinition col1 = taskManager.getCustomPropertyManager().createDefinition(
+        CustomPropertyManager.PropertyTypeEncoder.encodeFieldType(Integer.class), "col1", null);
+    col1.getAttributes().put(CustomPropertyMapping.MSPROJECT_TYPE, "NUMBER3");
+
+    Map<CustomPropertyDefinition, FieldType> mapping = CustomPropertyMapping.buildMapping(taskManager);
+    assertEquals(TaskField.NUMBER3, mapping.get(col1));
+    assertEquals(TaskField.NUMBER4, mapping.get(col2));
+    assertEquals(TaskField.COST10, mapping.get(col3));
+    assertEquals(TaskField.NUMBER2, mapping.get(col4));
+    assertEquals(TaskField.NUMBER1, mapping.get(col5));
+  }
+}

--- a/ganttproject/src/net/sourceforge/ganttproject/CustomPropertyDefinition.java
+++ b/ganttproject/src/net/sourceforge/ganttproject/CustomPropertyDefinition.java
@@ -3,7 +3,7 @@ Copyright 2003-2012 Dmitry Barashev, GanttProject Team
 
 This file is part of GanttProject, an opensource project management tool.
 
-GanttProject is free software: you can redistribute it and/or modify 
+GanttProject is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
  the Free Software Foundation, either version 3 of the License, or
  (at your option) any later version.
@@ -20,7 +20,11 @@ package net.sourceforge.ganttproject;
 
 import org.eclipse.core.runtime.IStatus;
 
+import javax.annotation.Nonnull;
+import java.util.Map;
+
 public interface CustomPropertyDefinition {
+  @Nonnull
   CustomPropertyClass getPropertyClass();
 
   IStatus canSetPropertyClass(CustomPropertyClass propertyClass);
@@ -35,6 +39,7 @@ public interface CustomPropertyDefinition {
 
   Object getDefaultValue();
 
+  @Nonnull
   String getName();
 
   void setName(String name);
@@ -42,4 +47,7 @@ public interface CustomPropertyDefinition {
   String getDefaultValueAsString();
 
   void setDefaultValueAsString(String value);
+
+  @Nonnull
+  Map<String, String> getAttributes();
 }

--- a/ganttproject/src/net/sourceforge/ganttproject/CustomPropertyManager.java
+++ b/ganttproject/src/net/sourceforge/ganttproject/CustomPropertyManager.java
@@ -18,20 +18,20 @@ along with GanttProject.  If not, see <http://www.gnu.org/licenses/>.
  */
 package net.sourceforge.ganttproject;
 
-import java.util.Date;
-import java.util.GregorianCalendar;
-import java.util.List;
-import java.util.Map;
-
+import biz.ganttproject.core.time.CalendarFactory;
 import net.sourceforge.ganttproject.language.GanttLanguage;
 import net.sourceforge.ganttproject.util.StringUtils;
-
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 import org.w3c.util.DateParser;
 import org.w3c.util.InvalidDateException;
 
-import biz.ganttproject.core.time.CalendarFactory;
+import javax.annotation.Nonnull;
+import java.util.Collections;
+import java.util.Date;
+import java.util.GregorianCalendar;
+import java.util.List;
+import java.util.Map;
 
 public interface CustomPropertyManager {
   List<CustomPropertyDefinition> getDefinitions();
@@ -67,8 +67,8 @@ public interface CustomPropertyManager {
       return result;
     }
 
-    public static CustomPropertyDefinition decodeTypeAndDefaultValue(final String typeAsString,
-        final String valueAsString) {
+    public static CustomPropertyDefinition decodeTypeAndDefaultValue(
+        final String typeAsString, final String valueAsString) {
       final CustomPropertyClass propertyClass;
       final Object defaultValue;
       if (typeAsString.equals("text")) {
@@ -128,11 +128,18 @@ public interface CustomPropertyManager {
           throw new UnsupportedOperationException();
         }
 
+        @Nonnull
+        @Override
+        public Map<String, String> getAttributes() {
+          return Collections.emptyMap();
+        }
+
         @Override
         public String getID() {
           return null;
         }
 
+        @Nonnull
         @Override
         public String getName() {
           return null;
@@ -153,6 +160,7 @@ public interface CustomPropertyManager {
           return typeAsString;
         }
 
+        @Nonnull
         @Override
         public CustomPropertyClass getPropertyClass() {
           return propertyClass;

--- a/ganttproject/src/net/sourceforge/ganttproject/CustomPropertyManager.java
+++ b/ganttproject/src/net/sourceforge/ganttproject/CustomPropertyManager.java
@@ -61,7 +61,7 @@ public interface CustomPropertyManager {
         result = "int";
       } else if (fieldType.equals(Double.class)) {
         result = "double";
-      } else if (fieldType.isAssignableFrom(GregorianCalendar.class)) {
+      } else if (GregorianCalendar.class.isAssignableFrom(fieldType)) {
         result = "date";
       }
       return result;

--- a/ganttproject/src/net/sourceforge/ganttproject/DefaultCustomPropertyDefinition.java
+++ b/ganttproject/src/net/sourceforge/ganttproject/DefaultCustomPropertyDefinition.java
@@ -21,6 +21,10 @@ package net.sourceforge.ganttproject;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 
+import javax.annotation.Nonnull;
+import java.util.HashMap;
+import java.util.Map;
+
 public class DefaultCustomPropertyDefinition implements CustomPropertyDefinition {
   private String myName;
   private final String myID;
@@ -28,6 +32,7 @@ public class DefaultCustomPropertyDefinition implements CustomPropertyDefinition
   private String myDefaultValueAsString;
   private CustomPropertyClass myPropertyClass;
   private String myTypeAsString;
+  private final Map<String, String> myAttributes = new HashMap<>();
 
   public DefaultCustomPropertyDefinition(String name) {
     myName = name;
@@ -65,11 +70,18 @@ public class DefaultCustomPropertyDefinition implements CustomPropertyDefinition
     myDefaultValueAsString = stub.getDefaultValueAsString();
   }
 
+  @Nonnull
+  @Override
+  public Map<String, String> getAttributes() {
+    return myAttributes;
+  }
+
   @Override
   public String getID() {
     return myID;
   }
 
+  @Nonnull
   @Override
   public String getName() {
     return myName;
@@ -85,6 +97,7 @@ public class DefaultCustomPropertyDefinition implements CustomPropertyDefinition
     return myPropertyClass.getJavaClass();
   }
 
+  @Nonnull
   @Override
   public CustomPropertyClass getPropertyClass() {
     return myPropertyClass;

--- a/ganttproject/src/net/sourceforge/ganttproject/importer/ImporterBase.java
+++ b/ganttproject/src/net/sourceforge/ganttproject/importer/ImporterBase.java
@@ -18,12 +18,6 @@ along with GanttProject.  If not, see <http://www.gnu.org/licenses/>.
  */
 package net.sourceforge.ganttproject.importer;
 
-import java.io.File;
-import java.util.List;
-import java.util.logging.Level;
-
-import org.osgi.service.prefs.Preferences;
-
 import biz.ganttproject.core.option.GPOption;
 import biz.ganttproject.core.option.GPOptionGroup;
 import net.sourceforge.ganttproject.GPLogger;
@@ -33,6 +27,11 @@ import net.sourceforge.ganttproject.gui.UIFacade;
 import net.sourceforge.ganttproject.language.GanttLanguage;
 import net.sourceforge.ganttproject.util.collect.Pair;
 import net.sourceforge.ganttproject.wizard.WizardPage;
+import org.osgi.service.prefs.Preferences;
+
+import java.io.File;
+import java.util.List;
+import java.util.logging.Level;
 
 public abstract class ImporterBase implements Importer {
   private final String myID;
@@ -124,6 +123,10 @@ public abstract class ImporterBase implements Importer {
   }
 
   protected void reportErrors(List<Pair<Level, String>> errors, String loggerName) {
+    reportErrors(getUiFacade(), errors, loggerName);
+  }
+
+  public static void reportErrors(UIFacade uiFacade, List<Pair<Level, String>> errors, String loggerName) {
     if (!errors.isEmpty()) {
       StringBuilder builder = new StringBuilder("<table><tr><th>Severity</th><th>Message</th></tr>");
       for (Pair<Level, String> message : errors) {
@@ -131,7 +134,7 @@ public abstract class ImporterBase implements Importer {
         builder.append(String.format("<tr><td valign=top><b>%s</b></td><td valign=top>%s</td></tr>", message.first().getName(), message.second()));
       }
       builder.append("</table>");
-      getUiFacade().showNotificationDialog(NotificationChannel.WARNING,
+      uiFacade.showNotificationDialog(NotificationChannel.WARNING,
           GanttLanguage.getInstance().formatText("impex." + loggerName.toLowerCase() + ".importErrorReport", builder.toString()));
     }
   }

--- a/ganttproject/src/net/sourceforge/ganttproject/io/ResourceSaver.java
+++ b/ganttproject/src/net/sourceforge/ganttproject/io/ResourceSaver.java
@@ -18,19 +18,18 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 package net.sourceforge.ganttproject.io;
 
-import java.math.BigDecimal;
-import java.util.List;
-
-import javax.xml.transform.sax.TransformerHandler;
-
-import org.xml.sax.SAXException;
-import org.xml.sax.helpers.AttributesImpl;
-
 import net.sourceforge.ganttproject.CustomProperty;
 import net.sourceforge.ganttproject.CustomPropertyDefinition;
 import net.sourceforge.ganttproject.CustomPropertyManager;
 import net.sourceforge.ganttproject.IGanttProject;
 import net.sourceforge.ganttproject.resource.HumanResource;
+import org.xml.sax.SAXException;
+import org.xml.sax.helpers.AttributesImpl;
+
+import javax.xml.transform.sax.TransformerHandler;
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Map;
 
 class ResourceSaver extends SaverBase {
   void save(IGanttProject project, TransformerHandler handler) throws SAXException {
@@ -102,6 +101,9 @@ class ResourceSaver extends SaverBase {
       addAttribute("name", nextDefinition.getName(), attrs);
       addAttribute("type", nextDefinition.getTypeAsString(), attrs);
       addAttribute("default-value", nextDefinition.getDefaultValueAsString(), attrs);
+      for (Map.Entry<String,String> kv : nextDefinition.getAttributes().entrySet()) {
+        addAttribute(kv.getKey(), kv.getValue(), attrs);
+      }
       emptyElement("custom-property-definition", attrs, handler);
     }
     // endElement("custom-properties-definition", handler);

--- a/ganttproject/src/net/sourceforge/ganttproject/io/TaskSaver.java
+++ b/ganttproject/src/net/sourceforge/ganttproject/io/TaskSaver.java
@@ -18,14 +18,8 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 package net.sourceforge.ganttproject.io;
 
-import java.io.IOException;
-import java.math.BigDecimal;
-import java.net.URLEncoder;
-import java.util.Date;
-import java.util.GregorianCalendar;
-
-import javax.xml.transform.sax.TransformerHandler;
-
+import biz.ganttproject.core.time.GanttCalendar;
+import com.google.common.base.Charsets;
 import net.sourceforge.ganttproject.CustomPropertyDefinition;
 import net.sourceforge.ganttproject.CustomPropertyManager;
 import net.sourceforge.ganttproject.GanttTask;
@@ -34,14 +28,18 @@ import net.sourceforge.ganttproject.task.CustomColumnsValues;
 import net.sourceforge.ganttproject.task.Task;
 import net.sourceforge.ganttproject.task.dependency.TaskDependency;
 import net.sourceforge.ganttproject.util.ColorConvertion;
-
 import org.w3c.util.DateParser;
 import org.xml.sax.SAXException;
 import org.xml.sax.helpers.AttributesImpl;
 
-import com.google.common.base.Charsets;
-
-import biz.ganttproject.core.time.GanttCalendar;
+import javax.xml.transform.sax.TransformerHandler;
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.net.URLEncoder;
+import java.util.Collections;
+import java.util.Date;
+import java.util.GregorianCalendar;
+import java.util.Map;
 
 class TaskSaver extends SaverBase {
   void save(IGanttProject project, TransformerHandler handler) throws SAXException, IOException {
@@ -151,11 +149,11 @@ class TaskSaver extends SaverBase {
 
   private void writeTaskProperty(TransformerHandler handler, String id, String name, String type, String valueType)
       throws SAXException {
-    writeTaskProperty(handler, id, name, type, valueType, null);
+    writeTaskProperty(handler, id, name, type, valueType, null, Collections.<String,String>emptyMap());
   }
 
   private void writeTaskProperty(TransformerHandler handler, String id, String name, String type, String valueType,
-      String defaultValue) throws SAXException {
+                                 String defaultValue, Map<String, String> attributes) throws SAXException {
     AttributesImpl attrs = new AttributesImpl();
     addAttribute("id", id, attrs);
     addAttribute("name", name, attrs);
@@ -163,6 +161,9 @@ class TaskSaver extends SaverBase {
     addAttribute("valuetype", valueType, attrs);
     if (defaultValue != null) {
       addAttribute("defaultvalue", defaultValue, attrs);
+    }
+    for (Map.Entry<String,String> kv : attributes.entrySet()) {
+      addAttribute(kv.getKey(), kv.getValue(), attrs);
     }
     emptyElement("taskproperty", attrs, handler);
   }
@@ -198,7 +199,7 @@ class TaskSaver extends SaverBase {
       }
       String idcStr = cc.getID();
       writeTaskProperty(handler, idcStr, cc.getName(), "custom", valueType,
-          defVal == null ? null : String.valueOf(defVal));
+          defVal == null ? null : String.valueOf(defVal), cc.getAttributes());
     }
   }
 

--- a/ganttproject/src/net/sourceforge/ganttproject/task/CustomColumn.java
+++ b/ganttproject/src/net/sourceforge/ganttproject/task/CustomColumn.java
@@ -26,6 +26,10 @@ import net.sourceforge.ganttproject.CustomPropertyDefinition;
 import net.sourceforge.ganttproject.CustomPropertyManager;
 import net.sourceforge.ganttproject.DefaultCustomPropertyDefinition;
 
+import javax.annotation.Nonnull;
+import java.util.HashMap;
+import java.util.Map;
+
 public class CustomColumn implements CustomPropertyDefinition {
   private String id = null;
 
@@ -36,6 +40,7 @@ public class CustomColumn implements CustomPropertyDefinition {
   private final CustomColumnsManager myManager;
 
   private CustomPropertyClass myPropertyClass;
+  private final Map<String, String> myAttributes = new HashMap<>();
 
   CustomColumn(CustomColumnsManager manager, String colName, CustomPropertyClass propertyClass, Object colDefaultValue) {
     name = colName;
@@ -68,6 +73,13 @@ public class CustomColumn implements CustomPropertyDefinition {
     defaultValue = stub.getDefaultValue();
   }
 
+  @Nonnull
+  @Override
+  public Map<String, String> getAttributes() {
+    return myAttributes;
+  }
+
+  @Nonnull
   @Override
   public String getName() {
     return name;
@@ -80,6 +92,7 @@ public class CustomColumn implements CustomPropertyDefinition {
     myManager.fireDefinitionChanged(this, oldName);
   }
 
+  @Nonnull
   @Override
   public CustomPropertyClass getPropertyClass() {
     return myPropertyClass;

--- a/ganttproject/src/net/sourceforge/ganttproject/task/CustomColumnsStorage.java
+++ b/ganttproject/src/net/sourceforge/ganttproject/task/CustomColumnsStorage.java
@@ -18,6 +18,12 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 package net.sourceforge.ganttproject.task;
 
+import com.google.common.base.Objects;
+import net.sourceforge.ganttproject.CustomPropertyDefinition;
+import net.sourceforge.ganttproject.CustomPropertyListener;
+import net.sourceforge.ganttproject.DefaultCustomPropertyDefinition;
+import net.sourceforge.ganttproject.language.GanttLanguage;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -26,17 +32,10 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
-import com.google.common.base.Objects;
-
-import net.sourceforge.ganttproject.CustomPropertyDefinition;
-import net.sourceforge.ganttproject.CustomPropertyListener;
-import net.sourceforge.ganttproject.DefaultCustomPropertyDefinition;
-import net.sourceforge.ganttproject.language.GanttLanguage;
-
 /**
  * TODO Remove the map Name->customColum to keep only the map Id -> CustomColumn
  * This class stores the CustomColumns.
- * 
+ *
  * @author bbaranne (Benoit Baranne) Mar 2, 2005
  */
 public class CustomColumnsStorage {
@@ -110,6 +109,7 @@ public class CustomColumnsStorage {
       if (thisColumn == null || !thisColumn.getPropertyClass().equals(thatColumn.getPropertyClass())) {
         thisColumn = new CustomColumn(myManager, thatColumn.getName(), thatColumn.getPropertyClass(), thatColumn.getDefaultValue());
         thisColumn.setId(createId());
+        thisColumn.getAttributes().putAll(thatColumn.getAttributes());
         addCustomColumn(thisColumn);
       }
       result.put(thatColumn, thisColumn);


### PR DESCRIPTION
Fixes issue #1390 

### Summary of what went wrong and how it was fixed:
When importing from MS Project we may create a number of "custom properties" named like "Number1", "Text5", etc. They get types in GanttProject: text fields get type String, number are mapped to Double, etc. Unfortunately the set of types in GP is not as broad as the set of types in MS Project, and we map e.g. NumberX and CostX properties to the same type Double. When exporting back to MS Project they are mapped to NumberX fields and we just run out of available fields (enums in TaskField and ResourceField classes in MPXJ library include limited number of fields of each type). 

The solution is to record MS Project type in GP custom properties when importing and use the recorded type in the export. That will work for future imports. For MS projects imported into GP earlier we added a special hack: we examine their name and if it looks like "NumberX" then we search for corresponding enum constant in MPXJ.