### PR TITLE
Default directory in import file chooser should be consistent with export. 

### DIFF
--- a/ganttproject/src/net/sourceforge/ganttproject/gui/TextFieldAndFileChooserComponent.java
+++ b/ganttproject/src/net/sourceforge/ganttproject/gui/TextFieldAndFileChooserComponent.java
@@ -272,7 +272,7 @@ public abstract class TextFieldAndFileChooserComponent extends JPanel {
     myUiFacade.createDialog(fc, dialogActions, "").show();
   }
 
-  private File getWorkingDir() {
+  protected File getWorkingDir() {
     return new File(System.getProperty("user.dir"));
   }
 

--- a/ganttproject/src/net/sourceforge/ganttproject/importer/FileChooserPage.java
+++ b/ganttproject/src/net/sourceforge/ganttproject/importer/FileChooserPage.java
@@ -42,8 +42,8 @@ class FileChooserPage extends AbstractFileChooserPage {
   private final Importer myImporter;
   private File myFile;
 
-  public FileChooserPage(UIFacade uiFacade, Importer importer, Preferences prefs) {
-    super(uiFacade, prefs, GanttLanguage.getInstance().getText("importerFileChooserPageTitle"), createFileFilter(importer), createOptions(importer), false);
+  public FileChooserPage(UIFacade uiFacade, Importer importer, Preferences prefs, File defaultFolder) {
+    super(uiFacade, prefs, GanttLanguage.getInstance().getText("importerFileChooserPageTitle"), createFileFilter(importer), createOptions(importer), false, defaultFolder);
     myImporter = importer;
   }
 

--- a/ganttproject/src/net/sourceforge/ganttproject/importer/ImportFileWizardImpl.java
+++ b/ganttproject/src/net/sourceforge/ganttproject/importer/ImportFileWizardImpl.java
@@ -44,7 +44,7 @@ public class ImportFileWizardImpl extends AbstractWizard {
 
   public ImportFileWizardImpl(UIFacade uiFacade, IGanttProject project, GanttOptions options) {
     super(uiFacade, i18n.getText("importWizard.dialog.title"),
-        new ImporterChooserPage(ourImporters, uiFacade, options.getPluginPreferences().node("/instance/net.sourceforge.ganttproject/import")));
+        new ImporterChooserPage(ourImporters, uiFacade, project, options.getPluginPreferences().node("/instance/net.sourceforge.ganttproject/import")));
     for (Importer importer : ourImporters) {
       importer.setContext(project, uiFacade, options.getPluginPreferences());
     }

--- a/ganttproject/src/net/sourceforge/ganttproject/importer/ImporterChooserPage.java
+++ b/ganttproject/src/net/sourceforge/ganttproject/importer/ImporterChooserPage.java
@@ -18,14 +18,15 @@ along with GanttProject.  If not, see <http://www.gnu.org/licenses/>.
  */
 package net.sourceforge.ganttproject.importer;
 
-import java.awt.Component;
 import java.awt.event.ActionEvent;
+import java.io.File;
 import java.util.List;
 
 import javax.swing.AbstractAction;
 import javax.swing.Action;
 import javax.swing.JComponent;
 
+import net.sourceforge.ganttproject.IGanttProject;
 import org.osgi.service.prefs.Preferences;
 
 import biz.ganttproject.core.option.GPOptionGroup;
@@ -40,15 +41,17 @@ import net.sourceforge.ganttproject.wizard.WizardPage;
  */
 class ImporterChooserPage implements WizardPage {
   private final List<Importer> myImporters;
+  private final IGanttProject myProject;
   private AbstractWizard myWizard;
   private final UIFacade myUiFacade;
   private final Preferences myPrefs;
   private int mySelectedIndex;
 
-  ImporterChooserPage(List<Importer> importers, UIFacade uiFacade, Preferences preferences) {
+  ImporterChooserPage(List<Importer> importers, UIFacade uiFacade, IGanttProject project, Preferences preferences) {
     myImporters = importers;
     myUiFacade = uiFacade;
     myPrefs = preferences;
+    myProject = project;
   }
 
   @Override
@@ -79,8 +82,12 @@ class ImporterChooserPage implements WizardPage {
 
   protected void onSelectImporter(Importer importer) {
     assert myWizard != null : "It is a bug: importer chooser has not been initialized properly";
-    WizardPage filePage = new FileChooserPage(myUiFacade, importer, myPrefs.node(importer.getID()));
+    WizardPage filePage = new FileChooserPage(myUiFacade, importer, myPrefs.node(importer.getID()), getDefaultFolder());
     myWizard.setNextPage(filePage);
+  }
+
+  private File getDefaultFolder() {
+    return new File(myProject.getDocumentManager().getWorkingDirectory());
   }
 
   @Override

--- a/ganttproject/src/net/sourceforge/ganttproject/wizard/AbstractFileChooserPage.java
+++ b/ganttproject/src/net/sourceforge/ganttproject/wizard/AbstractFileChooserPage.java
@@ -79,6 +79,7 @@ public abstract class AbstractFileChooserPage implements WizardPage {
       return true;
     }
   };
+  private final File myDefaulFolder ;
 
   private JPanel myComponent;
   private TextFieldAndFileChooserComponent myChooser;
@@ -96,13 +97,14 @@ public abstract class AbstractFileChooserPage implements WizardPage {
   private final String myTitle;
   private AbstractWizard myWizard;
 
-  protected AbstractFileChooserPage(UIFacade uiFacade, Preferences prefs, String title, FileFilter fileFilter, GPOptionGroup[] options, boolean enableUrlChooser) {
+  protected AbstractFileChooserPage(UIFacade uiFacade, Preferences prefs, String title, FileFilter fileFilter, GPOptionGroup[] options, boolean enableUrlChooser, File defaultFolder) {
     myUiFacade = uiFacade;
     myPreferences = prefs;
     myTitle = title;
     myFileFilter = Objects.firstNonNull(fileFilter, ACCEPT_ALL);
     myOptions = Objects.firstNonNull(options, new GPOptionGroup[0]);
     isUrlChooserEnabled = enableUrlChooser;
+    myDefaulFolder = defaultFolder;
     myOptionsBuilder = new OptionsPageBuilder();
     mySecondaryOptionsComponent = new JPanel(new BorderLayout());
     mySecondaryOptionsComponent.setBorder(BorderFactory.createEmptyBorder(10, 0, 0, 0));
@@ -119,6 +121,11 @@ public abstract class AbstractFileChooserPage implements WizardPage {
       @Override
       protected void onFileChosen(File file) {
         AbstractFileChooserPage.this.onSelectedFileChange(file);
+      }
+
+      @Override
+      protected File getWorkingDir() {
+        return myDefaulFolder;
       }
     };
     myChooser.setFileSelectionMode(getFileChooserSelectionMode());


### PR DESCRIPTION
Export file chooser uses user home folder while import uses current OS folder This makes user to do a lot of extra clicks choosing correct folder if several export-import cycles are needed.
This fix makes import file chooser to use user home folder (taken from DocumentManager.getWorkingDirectory() )