### PR TITLE
Fixed PDF export for resource total load

### DIFF
--- a/org.ganttproject.impex.htmlpdf/src/org/ganttproject/impex/htmlpdf/itext/ThemeImpl.java
+++ b/org.ganttproject.impex.htmlpdf/src/org/ganttproject/impex/htmlpdf/itext/ThemeImpl.java
@@ -425,7 +425,8 @@ class ThemeImpl extends StylesheetImpl implements PdfPageEvent, ITextStylesheet 
         cell = new PdfPCell(p);
         if (TaskDefaultColumn.COST.getStub().getID().equals(column.getID())
             || ResourceDefaultColumn.STANDARD_RATE.getStub().getID().equals(column.getID())
-            || ResourceDefaultColumn.TOTAL_COST.getStub().getID().equals(column.getID())) {
+            || ResourceDefaultColumn.TOTAL_COST.getStub().getID().equals(column.getID())
+            || ResourceDefaultColumn.TOTAL_LOAD.getStub().getID().equals(column.getID())) {
           cell.setHorizontalAlignment(PdfPCell.ALIGN_RIGHT);
         }
         cell.setBorderWidth(0);


### PR DESCRIPTION
Hi there,

now the PDF export of the total load of a resource is aligned at the right side of the column.

Cheers,
Christoph