### PR TITLE
improving format of exported excel

### DIFF
--- a/ganttproject-tester/test/biz/ganttproject/impex/csv/CsvImportTest.java
+++ b/ganttproject-tester/test/biz/ganttproject/impex/csv/CsvImportTest.java
@@ -229,7 +229,7 @@ public class CsvImportTest extends TestCase {
 
   private byte[] createXls(String... rows) throws Exception {
     ByteArrayOutputStream stream = new ByteArrayOutputStream();
-    try (SpreadsheetWriter writer = new XlsWriterImpl(stream)) {
+    try (SpreadsheetWriter writer = new XlsWriterImpl(stream, "test")) {
       for (String row : rows) {
         for (String cell : row.split(",", -1)) {
           writer.print(cell.trim());

--- a/ganttproject-tester/test/biz/ganttproject/impex/csv/GPCsvImportTest.java
+++ b/ganttproject-tester/test/biz/ganttproject/impex/csv/GPCsvImportTest.java
@@ -334,7 +334,7 @@ public class GPCsvImportTest extends TestCase {
 
   private byte[] createXls(String... rows) throws Exception {
     ByteArrayOutputStream stream = new ByteArrayOutputStream();
-    try (SpreadsheetWriter writer = new XlsWriterImpl(stream)) {
+    try (SpreadsheetWriter writer = new XlsWriterImpl(stream, "test")) {
       for (String row : rows) {
         for (String line : row.split("\n", -1)) {
           for (String cell : line.split(",", -1)) {

--- a/ganttproject/src/biz/ganttproject/impex/csv/CsvRecordImpl.java
+++ b/ganttproject/src/biz/ganttproject/impex/csv/CsvRecordImpl.java
@@ -35,7 +35,7 @@ class CsvRecordImpl implements SpreadsheetRecord {
 
   @Override
   public String get(String name) {
-    return myRecord.get(name);
+    return (isSet(name)) ? myRecord.get(name) : new String();
   }
 
   @Override

--- a/ganttproject/src/biz/ganttproject/impex/csv/CsvWriterImpl.java
+++ b/ganttproject/src/biz/ganttproject/impex/csv/CsvWriterImpl.java
@@ -26,6 +26,8 @@ import org.apache.commons.csv.CSVPrinter;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
+import java.math.BigDecimal;
+import java.util.Calendar;
 
 /**
  * @author akurutin on 04.04.2017.
@@ -52,5 +54,36 @@ public class CsvWriterImpl implements SpreadsheetWriter {
   public void close() throws IOException {
     myCsvPrinter.flush();
     myCsvPrinter.close();
+  }
+
+  @Override
+  public void newSheet() throws IOException {
+    println();
+    println();
+  }
+
+  @Override
+  public void newSheet(String name) throws IOException {
+    newSheet();
+  }
+
+  @Override
+  public void print(Double value) throws IOException {
+    myCsvPrinter.print(String.valueOf(value));
+  }
+
+  @Override
+  public void print(Integer value) throws IOException {
+    myCsvPrinter.print(String.valueOf(value));
+  }
+
+  @Override
+  public void print(BigDecimal value) throws IOException {
+    myCsvPrinter.print(value.toPlainString());
+  }
+
+  @Override
+  public void print(Calendar value) throws IOException {
+    myCsvPrinter.print(value.toString());
   }
 }

--- a/ganttproject/src/biz/ganttproject/impex/csv/GanttCSVExport.java
+++ b/ganttproject/src/biz/ganttproject/impex/csv/GanttCSVExport.java
@@ -114,15 +114,14 @@ public class GanttCSVExport {
   }
 
   private SpreadsheetWriter getXlsWriter(OutputStream stream) {
-    return new XlsWriterImpl(stream);
+    return new XlsWriterImpl(stream, i18n("tasksList"));
   }
 
   public void save(SpreadsheetWriter writer) throws IOException {
     writeTasks(writer);
 
     if (myHumanResourceManager.getResources().size() > 0) {
-      writer.println();
-      writer.println();
+      writer.newSheet(i18n("resourcesList"));
       writeResources(writer);
     }
   }
@@ -171,22 +170,22 @@ public class GanttCSVExport {
         } else {
           switch (defaultColumn) {
             case ID:
-              writer.print(String.valueOf(task.getTaskID()));
+              writer.print(task.getTaskID());
               break;
             case NAME:
               writer.print(getName(task));
               break;
             case BEGIN_DATE:
-              writer.print(task.getStart().toString());
+              writer.print(task.getStart());
               break;
             case END_DATE:
-              writer.print(task.getDisplayEnd().toString());
+              writer.print(task.getDisplayEnd());
               break;
             case DURATION:
-              writer.print(String.valueOf(task.getDuration().getLength()));
+              writer.print(task.getDuration().getLength());
               break;
             case COMPLETION:
-              writer.print(String.valueOf(task.getCompletionPercentage()));
+              writer.print(task.getCompletionPercentage());
               break;
             case OUTLINE_NUMBER:
               List<Integer> outlinePath = task.getManager().getTaskHierarchy().getOutlinePath(task);
@@ -203,7 +202,7 @@ public class GanttCSVExport {
               writer.print(getAssignments(task));
               break;
             case COST:
-              writer.print(task.getCost().getValue().toPlainString());
+              writer.print(task.getCost().getValue());
               break;
             case INFO:
             case PRIORITY:
@@ -282,13 +281,13 @@ public class GanttCSVExport {
               writer.print("");
               break;
             case STANDARD_RATE:
-              writer.print(p.getStandardPayRate().toPlainString());
+              writer.print(p.getStandardPayRate());
               break;
             case TOTAL_COST:
-              writer.print(p.getTotalCost().toPlainString());
+              writer.print(p.getTotalCost());
               break;
             case TOTAL_LOAD:
-              writer.print(String.valueOf(p.getTotalLoad()));
+              writer.print(p.getTotalLoad());
               break;
           }
         }

--- a/ganttproject/src/biz/ganttproject/impex/csv/SpreadsheetWriter.java
+++ b/ganttproject/src/biz/ganttproject/impex/csv/SpreadsheetWriter.java
@@ -20,6 +20,7 @@ along with GanttProject.  If not, see <http://www.gnu.org/licenses/>.
 package biz.ganttproject.impex.csv;
 
 import java.io.IOException;
+import java.math.BigDecimal;
 
 /**
  * @author akurutin on 04.04.2017.
@@ -27,6 +28,18 @@ import java.io.IOException;
 public interface SpreadsheetWriter extends AutoCloseable {
   void print(String value) throws IOException;
 
+  void print(Double value) throws IOException;
+
+  void print(Integer value) throws IOException;
+
+  void print(BigDecimal value) throws IOException;
+
+  void print(java.util.Calendar value) throws IOException;
+
   void println() throws IOException;
+
+  void newSheet() throws IOException;
+
+  void newSheet(String name) throws IOException;
 
 }

--- a/ganttproject/src/biz/ganttproject/impex/csv/XlsRecordImpl.java
+++ b/ganttproject/src/biz/ganttproject/impex/csv/XlsRecordImpl.java
@@ -44,7 +44,7 @@ class XlsRecordImpl implements SpreadsheetRecord {
     if (index == null) {
       throw new IllegalArgumentException(String.format("Mapping for %s not found, expected one of %s", name, myMapping.keySet()));
     }
-    return myValues.get(index);
+    return (myValues.size() <= index) ? new String() : myValues.get(index);
   }
 
   @Override


### PR DESCRIPTION
The exported XLS file uses strings for every exported value and a single sheet for task an resources. In order to use the file for doing some calculations you have to change the columns by hand to have the correct type and format.

I moved the formatting of exported values to the SpreadsheetWriter by overloading the print method. I also extended the interface to be able to use more than one sheet. Now the created XLS uses date and number formats for the exported values where appropriate and separate sheets for tasks and resources. The re-import of an export to XLS with new and old format is still possible. CSV im-/export remains unchanged.

This also fixes a  bug where empty (custom) properties at the end of a line couldn't be read as the mapping of headers to column number was missing.

PS: When I re-imported an export of the example project the cost and coordinator properties where imported as custom properties in addition to their actual target.