### PR TITLE
Export task colors in CSV

### DIFF
--- a/biz.ganttproject.core/src/biz/ganttproject/core/model/task/TaskDefaultColumn.java
+++ b/biz.ganttproject.core/src/biz/ganttproject/core/model/task/TaskDefaultColumn.java
@@ -18,6 +18,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 */
 package biz.ganttproject.core.model.task;
 
+import java.awt.Color;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.GregorianCalendar;
@@ -50,7 +51,8 @@ public enum TaskDefaultColumn {
   ID(new ColumnList.ColumnStub("tpd10", null, false, -1, 20), Integer.class, "tableColID", Functions.NOT_EDITABLE),
   OUTLINE_NUMBER(new ColumnList.ColumnStub("tpd11", null, false, 4, 20), String.class, "tableColOutline", Functions.NOT_EDITABLE),
   COST(new ColumnList.ColumnStub("tpd12", null, false, -1, 20), Double.class, "tableColCost"),
-  RESOURCES(new ColumnList.ColumnStub("tpd13", null, false, -1, 20), String.class, "resources", Functions.NOT_EDITABLE);
+  RESOURCES(new ColumnList.ColumnStub("tpd13", null, false, -1, 20), String.class, "resources", Functions.NOT_EDITABLE),
+  COLOR(new ColumnList.ColumnStub("tpd14", null, false, -1, 20), Color.class, "color");
 
   public interface LocaleApi {
     String i18n(String key);

--- a/ganttproject-tester/test/biz/ganttproject/impex/csv/CsvColorExImportTest.java
+++ b/ganttproject-tester/test/biz/ganttproject/impex/csv/CsvColorExImportTest.java
@@ -1,0 +1,112 @@
+package biz.ganttproject.impex.csv;
+
+import biz.ganttproject.core.model.task.TaskDefaultColumn;
+import biz.ganttproject.core.option.BooleanOption;
+import com.google.common.base.Supplier;
+import junit.framework.TestCase;
+import net.sourceforge.ganttproject.GanttTask;
+import net.sourceforge.ganttproject.TestSetupHelper;
+import net.sourceforge.ganttproject.io.CSVOptions;
+import net.sourceforge.ganttproject.language.GanttLanguage;
+import net.sourceforge.ganttproject.resource.HumanResourceManager;
+import net.sourceforge.ganttproject.roles.RoleManagerImpl;
+import net.sourceforge.ganttproject.task.CustomColumnsManager;
+import net.sourceforge.ganttproject.task.TaskManager;
+
+import java.awt.*;
+import java.io.*;
+import java.nio.file.FileAlreadyExistsException;
+import java.text.SimpleDateFormat;
+import java.util.Map;
+
+public class CsvColorExImportTest extends TestCase {
+
+    private static final String FILENAME_TEMPLATE = "test_gp_color_export_%d.csv";
+
+    private File testfile;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        TaskDefaultColumn.setLocaleApi(new TaskDefaultColumn.LocaleApi() {
+            @Override
+            public String i18n(String key) {
+                return GanttLanguage.getInstance().getText(key);
+            }
+        });
+        GanttLanguage.getInstance().setShortDateFormat(new SimpleDateFormat("dd/MM/yy"));
+        long timestamp = System.currentTimeMillis();
+        String tmpdir = System.getProperty("java.io.tmpdir");
+        testfile = new File(tmpdir, String.format(FILENAME_TEMPLATE, timestamp));
+        if (testfile.exists()) {
+            throw new FileAlreadyExistsException("The output file already exists");
+        }
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        super.tearDown();
+        testfile.delete();
+    }
+
+    public void testExportImportWithColor() throws IOException {
+        TaskManager outTaskManager = TestSetupHelper.newTaskManagerBuilder().build();
+        GanttTask task0 = outTaskManager.createTask();
+        GanttTask task1 = outTaskManager.createTask();
+        GanttTask task2 = outTaskManager.createTask();
+        int task0id = task0.getTaskID();
+        int task1id = task1.getTaskID();
+        int task2id = task2.getTaskID();
+        task0.setName("task0");
+        task1.setName("task1");
+        task2.setName("task2");
+        task0.setColor(Color.RED);
+        task1.setColor(Color.GREEN);
+        task2.setColor(new Color(42, 42, 42));
+
+        CSVOptions csvOptions = new CSVOptions();
+        //Without this, the test fails with an UnsupportedOperationException. Taken and adapted from GPCsvExportTest
+        for (Map.Entry<String, BooleanOption> entry : csvOptions.getTaskOptions().entrySet()) {
+            if (TaskDefaultColumn.find(entry.getKey()) == TaskDefaultColumn.OUTLINE_NUMBER) {
+                entry.getValue().setValue(false);
+            }
+        }
+        GanttCSVExport exporter = new GanttCSVExport(
+                outTaskManager,
+                new HumanResourceManager(null, new CustomColumnsManager()),
+                new RoleManagerImpl(),
+                csvOptions
+        );
+        OutputStream os = new FileOutputStream(testfile);
+        exporter.save(os);
+        os.close();
+
+        TestSetupHelper.TaskManagerBuilder inBuilder = TestSetupHelper.newTaskManagerBuilder();
+        TaskManager inTaskManager = inBuilder.build();
+        GanttCSVOpen importer = new GanttCSVOpen(
+                new Supplier<Reader>() {
+                    @Override
+                    public Reader get() {
+                        try {
+                            return new FileReader(testfile);
+                        } catch (FileNotFoundException e) {
+                            e.printStackTrace();
+                            return null;
+                        }
+                    }
+                },
+                inTaskManager,
+                null,
+                null,
+                inBuilder.getTimeUnitStack()
+        );
+        importer.load();
+
+        assertEquals(3, inTaskManager.getTaskCount());
+        assertEquals(Color.RED, inTaskManager.getTask(task0id).getColor());
+        assertEquals(Color.GREEN, inTaskManager.getTask(task1id).getColor());
+        assertEquals(new Color(42, 42, 42), inTaskManager.getTask(task2id).getColor());
+
+    }
+
+}

--- a/ganttproject/data/resources/language/i18n.properties
+++ b/ganttproject/data/resources/language/i18n.properties
@@ -55,6 +55,7 @@ colContact = Contact
 colMail = Mail
 colName = Name
 colorButton = Choose ...
+color = Color
 colors = Colors
 colPhone = Phone
 colRole = Default role

--- a/ganttproject/src/biz/ganttproject/impex/csv/GanttCSVExport.java
+++ b/ganttproject/src/biz/ganttproject/impex/csv/GanttCSVExport.java
@@ -43,9 +43,11 @@ import net.sourceforge.ganttproject.task.ResourceAssignment;
 import net.sourceforge.ganttproject.task.Task;
 import net.sourceforge.ganttproject.task.TaskManager;
 import net.sourceforge.ganttproject.task.TaskProperties;
+import net.sourceforge.ganttproject.util.ColorConvertion;
 import net.sourceforge.ganttproject.util.StringUtils;
 import org.apache.commons.csv.CSVFormat;
 
+import java.awt.Color;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.Arrays;
@@ -204,6 +206,9 @@ public class GanttCSVExport {
               break;
             case COST:
               writer.print(task.getCost().getValue().toPlainString());
+              break;
+            case COLOR:
+              writer.print(ColorConvertion.getColor(task.getColor()));
               break;
             case INFO:
             case PRIORITY:

--- a/ganttproject/src/biz/ganttproject/impex/csv/TaskRecords.java
+++ b/ganttproject/src/biz/ganttproject/impex/csv/TaskRecords.java
@@ -37,7 +37,9 @@ import net.sourceforge.ganttproject.task.TaskManager;
 import net.sourceforge.ganttproject.task.TaskProperties;
 import net.sourceforge.ganttproject.task.dependency.TaskDependency;
 import net.sourceforge.ganttproject.task.dependency.TaskDependencyException;
+import net.sourceforge.ganttproject.util.ColorConvertion;
 
+import java.awt.*;
 import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.Comparator;
@@ -82,6 +84,7 @@ class TaskRecords extends RecordGroup {
     ID(TaskDefaultColumn.ID.getNameKey()),
     NAME("tableColName"), BEGIN_DATE("tableColBegDate"), END_DATE("tableColEndDate"), WEB_LINK("webLink"),
     NOTES("notes"), COMPLETION("tableColCompletion"), RESOURCES("resources"), DURATION("tableColDuration"),
+    COLOR("color"),
     PREDECESSORS(TaskDefaultColumn.PREDECESSORS.getNameKey()), OUTLINE_NUMBER(TaskDefaultColumn.OUTLINE_NUMBER.getNameKey());
 
     private final String text;
@@ -164,6 +167,14 @@ class TaskRecords extends RecordGroup {
       String completion = record.get(TaskFields.COMPLETION.toString());
       if (!Strings.isNullOrEmpty(completion)) {
         builder = builder.withCompletion(Integer.parseInt(completion));
+      }
+    }
+    if (record.isSet(TaskDefaultColumn.COLOR.getName())) {
+      try {
+        Color taskColor = ColorConvertion.determineColor(getOrNull(record, TaskFields.COLOR.toString()));
+        builder.withColor(taskColor);
+      } catch (AssertionError e) {
+        GPLogger.logToLogger(e);
       }
     }
     if (record.isSet(TaskDefaultColumn.COST.getName())) {

--- a/ganttproject/src/net/sourceforge/ganttproject/GPTreeTableBase.java
+++ b/ganttproject/src/net/sourceforge/ganttproject/GPTreeTableBase.java
@@ -255,8 +255,11 @@ public abstract class GPTreeTableBase extends JXTreeTable implements CustomPrope
           if (test1 != 0) {
             return test1;
           }
-          if (!left.getStub().isVisible() && !right.getStub().isVisible()) {
+          if (!left.getStub().isVisible() && !right.getStub().isVisible() && left.getName()!=null && right.getName()!=null) {
             return left.getName().compareTo(right.getName());
+          }
+          if(left.getStub().getOrder()==right.getStub().getOrder()){
+            return left.getStub().getID().compareTo( right.getStub().getID() );
           }
           return left.getStub().getOrder() - right.getStub().getOrder();
         }

--- a/ganttproject/src/net/sourceforge/ganttproject/GanttOptions.java
+++ b/ganttproject/src/net/sourceforge/ganttproject/GanttOptions.java
@@ -665,6 +665,8 @@ public class GanttOptions extends SaverBase {
               csvOptions.getTaskOptions().get(TaskDefaultColumn.COMPLETION.getStub().getID()).setValue(Boolean.valueOf(value));
             } else if (aName.equals("duration")) {
               csvOptions.getTaskOptions().get(TaskDefaultColumn.DURATION.getStub().getID()).setValue(Boolean.valueOf(value));
+            } else if (aName.equals("color")) {
+              csvOptions.getTaskOptions().get(TaskDefaultColumn.COLOR.getStub().getID()).setValue(Boolean.valueOf(value));
             } else if (aName.equals("webLink")) {
               csvOptions.getTaskOptions().get("webLink").setValue(Boolean.valueOf(value));
             } else if (aName.equals("resources")) {

--- a/ganttproject/src/net/sourceforge/ganttproject/GanttTreeTableModel.java
+++ b/ganttproject/src/net/sourceforge/ganttproject/GanttTreeTableModel.java
@@ -314,6 +314,9 @@ public class GanttTreeTableModel extends DefaultTreeTableModel implements TableC
       case COST:
         res = t.getCost().getValue();
         break;
+      case COLOR:
+        res = t.getColor();
+        break;
       case RESOURCES:
     	List<String> resources = Lists.transform(Arrays.asList(t.getAssignments()), new Function<ResourceAssignment, String>() {
 			@Override


### PR DESCRIPTION
This implements the feature requested in #1382, namely exporting and importing a task's color to and from CSV. Includes a unit test that actually exports to a file, reimports the file and checks whether colors still match.