### PR TITLE
Ignore action events issued from Apple screen menu

### DIFF
--- a/ganttproject/src/net/sourceforge/ganttproject/action/GPAction.java
+++ b/ganttproject/src/net/sourceforge/ganttproject/action/GPAction.java
@@ -225,6 +225,19 @@ public abstract class GPAction extends AbstractAction implements GanttLanguage.L
     updateTooltip();
   }
 
+  protected boolean calledFromAppleScreenMenu(ActionEvent e) {
+    if (String.valueOf(e.getSource()).indexOf("JMenu") == -1) {
+      return false;
+    }
+    StackTraceElement[] stackTrace = Thread.currentThread().getStackTrace();
+    for (int i = 0; i < Math.min(10, stackTrace.length); i++) {
+      if (stackTrace[i].getClassName().indexOf("ScreenMenuItem") > 0) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   protected void updateTooltip() {
     String description = getLocalizedDescription();
     putValue(Action.SHORT_DESCRIPTION, Strings.isNullOrEmpty(description) ? null : description);

--- a/ganttproject/src/net/sourceforge/ganttproject/action/edit/CopyAction.java
+++ b/ganttproject/src/net/sourceforge/ganttproject/action/edit/CopyAction.java
@@ -37,6 +37,9 @@ public class CopyAction extends GPAction {
 
   @Override
   public void actionPerformed(ActionEvent e) {
+    if (calledFromAppleScreenMenu(e)) {
+      return;
+    }
     myViewmanager.getSelectedArtefacts().startCopyClipboardTransaction();
   }
 

--- a/ganttproject/src/net/sourceforge/ganttproject/action/edit/CutAction.java
+++ b/ganttproject/src/net/sourceforge/ganttproject/action/edit/CutAction.java
@@ -40,6 +40,9 @@ public class CutAction extends GPAction {
 
   @Override
   public void actionPerformed(ActionEvent e) {
+    if (calledFromAppleScreenMenu(e)) {
+      return;
+    }
     myUndoManager.undoableEdit(getLocalizedName(), new Runnable() {
       @Override
       public void run() {

--- a/ganttproject/src/net/sourceforge/ganttproject/action/edit/PasteAction.java
+++ b/ganttproject/src/net/sourceforge/ganttproject/action/edit/PasteAction.java
@@ -71,6 +71,9 @@ public class PasteAction extends GPAction {
 
   @Override
   public void actionPerformed(ActionEvent evt) {
+    if (calledFromAppleScreenMenu(evt)) {
+      return;
+    }
     ChartSelection selection = myViewmanager.getSelectedArtefacts();
     if (!selection.isEmpty()) {
       pasteInternalFlavor(selection);

--- a/ganttproject/src/net/sourceforge/ganttproject/action/edit/RedoAction.java
+++ b/ganttproject/src/net/sourceforge/ganttproject/action/edit/RedoAction.java
@@ -50,6 +50,10 @@ public class RedoAction extends GPAction implements GPUndoListener {
 
   @Override
   public void actionPerformed(ActionEvent e) {
+    if (calledFromAppleScreenMenu(e)) {
+      return;
+    }
+
     myUndoManager.redo();
   }
 

--- a/ganttproject/src/net/sourceforge/ganttproject/action/edit/RefreshViewAction.java
+++ b/ganttproject/src/net/sourceforge/ganttproject/action/edit/RefreshViewAction.java
@@ -18,10 +18,10 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 package net.sourceforge.ganttproject.action.edit;
 
-import java.awt.event.ActionEvent;
-
 import net.sourceforge.ganttproject.action.GPAction;
 import net.sourceforge.ganttproject.gui.UIFacade;
+
+import java.awt.event.ActionEvent;
 
 public class RefreshViewAction extends GPAction {
 
@@ -33,7 +33,10 @@ public class RefreshViewAction extends GPAction {
   }
 
   @Override
-  public void actionPerformed(ActionEvent ae) {
+  public void actionPerformed(ActionEvent e) {
+    if (calledFromAppleScreenMenu(e)) {
+      return;
+    }
     myUIFacade.refresh();
   }
 

--- a/ganttproject/src/net/sourceforge/ganttproject/action/edit/SettingsDialogAction.java
+++ b/ganttproject/src/net/sourceforge/ganttproject/action/edit/SettingsDialogAction.java
@@ -18,12 +18,12 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 package net.sourceforge.ganttproject.action.edit;
 
-import java.awt.event.ActionEvent;
-
 import net.sourceforge.ganttproject.IGanttProject;
 import net.sourceforge.ganttproject.action.GPAction;
 import net.sourceforge.ganttproject.gui.UIFacade;
 import net.sourceforge.ganttproject.gui.options.SettingsDialog2;
+
+import java.awt.event.ActionEvent;
 
 /**
  * Action to show the options dialog for the application. It will seach and show
@@ -41,6 +41,9 @@ public class SettingsDialogAction extends GPAction {
 
   @Override
   public void actionPerformed(ActionEvent e) {
+    if (calledFromAppleScreenMenu(e)) {
+      return;
+    }
     SettingsDialog2 dialog = new SettingsDialog2(myProject, myUiFacade, "settings.app.pageOrder");
     dialog.show();
   }

--- a/ganttproject/src/net/sourceforge/ganttproject/action/edit/UndoAction.java
+++ b/ganttproject/src/net/sourceforge/ganttproject/action/edit/UndoAction.java
@@ -50,6 +50,10 @@ public class UndoAction extends GPAction implements GPUndoListener {
 
   @Override
   public void actionPerformed(ActionEvent e) {
+    if (calledFromAppleScreenMenu(e)) {
+      return;
+    }
+
     myUndoManager.undo();
   }
 

--- a/ganttproject/src/net/sourceforge/ganttproject/action/project/NewProjectAction.java
+++ b/ganttproject/src/net/sourceforge/ganttproject/action/project/NewProjectAction.java
@@ -18,10 +18,10 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 package net.sourceforge.ganttproject.action.project;
 
-import java.awt.event.ActionEvent;
-
 import net.sourceforge.ganttproject.GanttProject;
 import net.sourceforge.ganttproject.action.GPAction;
+
+import java.awt.event.ActionEvent;
 
 public class NewProjectAction extends GPAction {
   private GanttProject myMainFrame;
@@ -38,6 +38,9 @@ public class NewProjectAction extends GPAction {
 
   @Override
   public void actionPerformed(ActionEvent e) {
+    if (calledFromAppleScreenMenu(e)) {
+      return;
+    }
     myMainFrame.newProject();
   }
 }

--- a/ganttproject/src/net/sourceforge/ganttproject/action/project/OpenProjectAction.java
+++ b/ganttproject/src/net/sourceforge/ganttproject/action/project/OpenProjectAction.java
@@ -54,6 +54,9 @@ public class OpenProjectAction extends GPAction {
 
   @Override
   public void actionPerformed(ActionEvent e) {
+    if (calledFromAppleScreenMenu(e)) {
+      return;
+    }
     try {
       myProjectUiFacade.openProject(myProject);
     } catch (Exception ex) {

--- a/ganttproject/src/net/sourceforge/ganttproject/action/project/OpenURLAction.java
+++ b/ganttproject/src/net/sourceforge/ganttproject/action/project/OpenURLAction.java
@@ -18,15 +18,15 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 package net.sourceforge.ganttproject.action.project;
 
-import java.awt.event.ActionEvent;
-import java.io.IOException;
-
 import net.sourceforge.ganttproject.GPLogger;
 import net.sourceforge.ganttproject.IGanttProject;
 import net.sourceforge.ganttproject.document.Document;
 import net.sourceforge.ganttproject.document.Document.DocumentException;
 import net.sourceforge.ganttproject.gui.ProjectUIFacade;
 import net.sourceforge.ganttproject.gui.UIFacade;
+
+import java.awt.event.ActionEvent;
+import java.io.IOException;
 
 public class OpenURLAction extends CloudProjectActionBase {
   private final ProjectUIFacade myProjectUiFacade;
@@ -40,6 +40,9 @@ public class OpenURLAction extends CloudProjectActionBase {
 
   @Override
   public void actionPerformed(ActionEvent e) {
+    if (calledFromAppleScreenMenu(e)) {
+      return;
+    }
     if (myProjectUiFacade.ensureProjectSaved(myProject)) {
       try {
         openRemoteProject(myProject);

--- a/ganttproject/src/net/sourceforge/ganttproject/action/project/PrintAction.java
+++ b/ganttproject/src/net/sourceforge/ganttproject/action/project/PrintAction.java
@@ -18,10 +18,10 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 package net.sourceforge.ganttproject.action.project;
 
-import java.awt.event.ActionEvent;
-
 import net.sourceforge.ganttproject.GanttProject;
 import net.sourceforge.ganttproject.action.GPAction;
+
+import java.awt.event.ActionEvent;
 
 public class PrintAction extends GPAction {
 
@@ -39,6 +39,9 @@ public class PrintAction extends GPAction {
 
   @Override
   public void actionPerformed(ActionEvent e) {
+    if (calledFromAppleScreenMenu(e)) {
+      return;
+    }
     myMainFrame.printProject();
   }
 }

--- a/ganttproject/src/net/sourceforge/ganttproject/action/project/ProjectExportAction.java
+++ b/ganttproject/src/net/sourceforge/ganttproject/action/project/ProjectExportAction.java
@@ -18,15 +18,14 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 package net.sourceforge.ganttproject.action.project;
 
-import java.awt.event.ActionEvent;
-
-import org.osgi.service.prefs.Preferences;
-
 import net.sourceforge.ganttproject.IGanttProject;
 import net.sourceforge.ganttproject.action.GPAction;
 import net.sourceforge.ganttproject.export.ExportFileWizardImpl;
 import net.sourceforge.ganttproject.gui.UIFacade;
 import net.sourceforge.ganttproject.gui.projectwizard.WizardImpl;
+import org.osgi.service.prefs.Preferences;
+
+import java.awt.event.ActionEvent;
 
 /**
  * @author bard
@@ -52,6 +51,9 @@ public class ProjectExportAction extends GPAction {
 
   @Override
   public void actionPerformed(ActionEvent e) {
+    if (calledFromAppleScreenMenu(e)) {
+      return;
+    }
     WizardImpl wizard = new ExportFileWizardImpl(myUIFacade, myProject, myPluginPrerences);
     wizard.show();
   }

--- a/ganttproject/src/net/sourceforge/ganttproject/action/project/ProjectImportAction.java
+++ b/ganttproject/src/net/sourceforge/ganttproject/action/project/ProjectImportAction.java
@@ -18,13 +18,13 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 package net.sourceforge.ganttproject.action.project;
 
-import java.awt.event.ActionEvent;
-
 import net.sourceforge.ganttproject.GanttProject;
 import net.sourceforge.ganttproject.action.GPAction;
 import net.sourceforge.ganttproject.gui.UIFacade;
 import net.sourceforge.ganttproject.importer.ImportFileWizardImpl;
 import net.sourceforge.ganttproject.wizard.AbstractWizard;
+
+import java.awt.event.ActionEvent;
 
 /**
  * @author bard
@@ -43,6 +43,9 @@ public class ProjectImportAction extends GPAction {
 
   @Override
   public void actionPerformed(ActionEvent e) {
+    if (calledFromAppleScreenMenu(e)) {
+      return;
+    }
     AbstractWizard wizard = new ImportFileWizardImpl(myUIFacade, myProject, myProject.getGanttOptions());
     wizard.show();
   }

--- a/ganttproject/src/net/sourceforge/ganttproject/action/project/ProjectPreviewAction.java
+++ b/ganttproject/src/net/sourceforge/ganttproject/action/project/ProjectPreviewAction.java
@@ -18,14 +18,14 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 package net.sourceforge.ganttproject.action.project;
 
-import java.awt.event.ActionEvent;
-import java.util.Date;
-
 import net.sourceforge.ganttproject.GanttProject;
 import net.sourceforge.ganttproject.action.GPAction;
 import net.sourceforge.ganttproject.chart.Chart;
 import net.sourceforge.ganttproject.gui.UIFacade;
 import net.sourceforge.ganttproject.print.PrintPreview;
+
+import java.awt.event.ActionEvent;
+import java.util.Date;
 
 /**
  * @author bard
@@ -44,6 +44,9 @@ public class ProjectPreviewAction extends GPAction {
 
   @Override
   public void actionPerformed(ActionEvent e) {
+    if (calledFromAppleScreenMenu(e)) {
+      return;
+    }
     Date startDate, endDate;
     Chart chart = myUIFacade.getActiveChart();
     if (chart == null) {

--- a/ganttproject/src/net/sourceforge/ganttproject/action/project/ProjectPropertiesAction.java
+++ b/ganttproject/src/net/sourceforge/ganttproject/action/project/ProjectPropertiesAction.java
@@ -18,11 +18,11 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 package net.sourceforge.ganttproject.action.project;
 
-import java.awt.event.ActionEvent;
-
 import net.sourceforge.ganttproject.GanttProject;
 import net.sourceforge.ganttproject.action.GPAction;
 import net.sourceforge.ganttproject.gui.options.SettingsDialog2;
+
+import java.awt.event.ActionEvent;
 
 class ProjectPropertiesAction extends GPAction {
   private final GanttProject myMainFrame;
@@ -39,6 +39,9 @@ class ProjectPropertiesAction extends GPAction {
 
   @Override
   public void actionPerformed(ActionEvent e) {
+    if (calledFromAppleScreenMenu(e)) {
+      return;
+    }
     myMainFrame.getUIFacade().getUndoManager().undoableEdit(getI18n(getID()), new Runnable() {
       @Override
       public void run() {

--- a/ganttproject/src/net/sourceforge/ganttproject/action/project/SaveProjectAction.java
+++ b/ganttproject/src/net/sourceforge/ganttproject/action/project/SaveProjectAction.java
@@ -51,6 +51,9 @@ public class SaveProjectAction extends GPAction implements ProjectEventListener 
 
   @Override
   public void actionPerformed(ActionEvent e) {
+    if (calledFromAppleScreenMenu(e)) {
+      return;
+    }
     myMainFrame.saveProject();
   }
 

--- a/ganttproject/src/net/sourceforge/ganttproject/action/project/SaveProjectAsAction.java
+++ b/ganttproject/src/net/sourceforge/ganttproject/action/project/SaveProjectAsAction.java
@@ -18,10 +18,10 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 package net.sourceforge.ganttproject.action.project;
 
-import java.awt.event.ActionEvent;
-
 import net.sourceforge.ganttproject.GanttProject;
 import net.sourceforge.ganttproject.action.GPAction;
+
+import java.awt.event.ActionEvent;
 
 class SaveProjectAsAction extends GPAction {
   private GanttProject myMainFrame;
@@ -38,6 +38,9 @@ class SaveProjectAsAction extends GPAction {
 
   @Override
   public void actionPerformed(ActionEvent e) {
+    if (calledFromAppleScreenMenu(e)) {
+      return;
+    }
     myMainFrame.saveAsProject();
   }
 }

--- a/ganttproject/src/net/sourceforge/ganttproject/action/project/SaveURLAction.java
+++ b/ganttproject/src/net/sourceforge/ganttproject/action/project/SaveURLAction.java
@@ -18,13 +18,13 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 package net.sourceforge.ganttproject.action.project;
 
-import java.awt.event.ActionEvent;
-
 import net.sourceforge.ganttproject.GPLogger;
 import net.sourceforge.ganttproject.IGanttProject;
 import net.sourceforge.ganttproject.document.Document;
 import net.sourceforge.ganttproject.gui.ProjectUIFacade;
 import net.sourceforge.ganttproject.gui.UIFacade;
+
+import java.awt.event.ActionEvent;
 
 class SaveURLAction extends CloudProjectActionBase {
 
@@ -39,6 +39,9 @@ class SaveURLAction extends CloudProjectActionBase {
 
   @Override
   public void actionPerformed(ActionEvent e) {
+    if (calledFromAppleScreenMenu(e)) {
+      return;
+    }
     try {
       saveProjectRemotely(myProject);
     } catch (Exception ex) {

--- a/ganttproject/src/net/sourceforge/ganttproject/action/resource/ResourceNewAction.java
+++ b/ganttproject/src/net/sourceforge/ganttproject/action/resource/ResourceNewAction.java
@@ -55,6 +55,9 @@ public class ResourceNewAction extends ResourceAction {
 
   @Override
   public void actionPerformed(ActionEvent event) {
+    if (calledFromAppleScreenMenu(event)) {
+      return;
+    }
     final HumanResource resource = getManager().newHumanResource();
     resource.setRole(myRoleManager.getDefaultRole());
     GanttDialogPerson dp = new GanttDialogPerson(getManager().getCustomPropertyManager(), myUIFacade, resource);

--- a/ganttproject/src/net/sourceforge/ganttproject/action/resource/ResourcePropertiesAction.java
+++ b/ganttproject/src/net/sourceforge/ganttproject/action/resource/ResourcePropertiesAction.java
@@ -45,7 +45,10 @@ public class ResourcePropertiesAction extends ResourceAction {
   }
 
   @Override
-  public void actionPerformed(ActionEvent arg0) {
+  public void actionPerformed(ActionEvent e) {
+    if (calledFromAppleScreenMenu(e)) {
+      return;
+    }
     HumanResource[] selectedResources = getSelection();
     if (selectedResources.length > 0) {
       myUIFacade.getResourceTree().stopEditing();

--- a/ganttproject/src/net/sourceforge/ganttproject/action/task/TaskActionBase.java
+++ b/ganttproject/src/net/sourceforge/ganttproject/action/task/TaskActionBase.java
@@ -18,12 +18,6 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 package net.sourceforge.ganttproject.action.task;
 
-import java.awt.event.ActionEvent;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.List;
-
 import net.sourceforge.ganttproject.GanttTree2;
 import net.sourceforge.ganttproject.action.ActionDelegate;
 import net.sourceforge.ganttproject.action.ActionStateChangedListener;
@@ -35,6 +29,12 @@ import net.sourceforge.ganttproject.task.TaskContainmentHierarchyFacade;
 import net.sourceforge.ganttproject.task.TaskManager;
 import net.sourceforge.ganttproject.task.TaskSelectionManager;
 import net.sourceforge.ganttproject.task.dependency.TaskDependencyException;
+
+import java.awt.event.ActionEvent;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
 
 public abstract class TaskActionBase extends GPAction implements TaskSelectionManager.Listener, ActionDelegate {
   private final List<ActionStateChangedListener> myListeners = new ArrayList<ActionStateChangedListener>();
@@ -67,6 +67,9 @@ public abstract class TaskActionBase extends GPAction implements TaskSelectionMa
 
   @Override
   public void actionPerformed(ActionEvent e) {
+    if (calledFromAppleScreenMenu(e)) {
+      return;
+    }
     final List<Task> selection = new ArrayList<Task>(mySelection);
     Collections.sort(selection, new Comparator<Task>() {
       private final TaskContainmentHierarchyFacade myTaskHierarchy = getTaskManager().getTaskHierarchy();

--- a/ganttproject/src/net/sourceforge/ganttproject/action/task/TaskNewAction.java
+++ b/ganttproject/src/net/sourceforge/ganttproject/action/task/TaskNewAction.java
@@ -50,7 +50,7 @@ public class TaskNewAction extends GPAction {
 
   @Override
   public void actionPerformed(ActionEvent e) {
-    if (String.valueOf(e.getSource()).indexOf("JMenu") > 0 && calledFromAppleScreenMenu()) {
+    if (calledFromAppleScreenMenu(e)) {
       return;
     }
     myUiFacade.getUndoManager().undoableEdit(getLocalizedDescription(), new Runnable() {
@@ -67,16 +67,6 @@ public class TaskNewAction extends GPAction {
         myUiFacade.getTaskTree().startDefaultEditing(newTask);
       }
     });
-  }
-
-  private boolean calledFromAppleScreenMenu() {
-    StackTraceElement[] stackTrace = Thread.currentThread().getStackTrace();
-    for (int i = 0; i < Math.min(10, stackTrace.length); i++) {
-      if (stackTrace[i].getClassName().indexOf("ScreenMenuItem") > 0) {
-        return true;
-      }
-    }
-    return false;
   }
 
   protected TaskManager getTaskManager() {

--- a/ganttproject/src/net/sourceforge/ganttproject/action/task/TaskNewAction.java
+++ b/ganttproject/src/net/sourceforge/ganttproject/action/task/TaskNewAction.java
@@ -50,6 +50,9 @@ public class TaskNewAction extends GPAction {
 
   @Override
   public void actionPerformed(ActionEvent e) {
+    if (String.valueOf(e.getSource()).indexOf("JMenu") > 0 && calledFromAppleScreenMenu()) {
+      return;
+    }
     myUiFacade.getUndoManager().undoableEdit(getLocalizedDescription(), new Runnable() {
       @Override
       public void run() {
@@ -64,6 +67,16 @@ public class TaskNewAction extends GPAction {
         myUiFacade.getTaskTree().startDefaultEditing(newTask);
       }
     });
+  }
+
+  private boolean calledFromAppleScreenMenu() {
+    StackTraceElement[] stackTrace = Thread.currentThread().getStackTrace();
+    for (int i = 0; i < Math.min(10, stackTrace.length); i++) {
+      if (stackTrace[i].getClassName().indexOf("ScreenMenuItem") > 0) {
+        return true;
+      }
+    }
+    return false;
   }
 
   protected TaskManager getTaskManager() {


### PR DESCRIPTION
This hopefully fixes issue #1422 
The problems was that action would trigger twice on Mac OSX with native look and feel and Russian keyboard layout (this probably applies to other non-English layouts as well). The first event comes through the class `ScreenMenuItem` in some Apple-related package while the second passes through the normal Swing stack like on other platforms.

The same applies to other actions from the screen menu, e.g. Cmd+G would open two setting dialog windows.

This PR ignores events where source is "JMenu" and there is "ScreenMenuItem" class in the stack trace.