### PR TITLE
Fixes issue #1488: empty custom column names

### DIFF
--- a/biz.ganttproject.impex.msproject2/src/biz/ganttproject/impex/msproject2/ProjectFileExporter.java
+++ b/biz.ganttproject.impex.msproject2/src/biz/ganttproject/impex/msproject2/ProjectFileExporter.java
@@ -121,9 +121,7 @@ class ProjectFileExporter {
 //    Map<CustomPropertyDefinition, FieldType> customProperty_fieldType = new HashMap<CustomPropertyDefinition, FieldType>();
 //    collectCustomProperties(getTaskManager().getCustomPropertyManager(), customProperty_fieldType, TaskField.class);
     Map<CustomPropertyDefinition, FieldType> customProperty_fieldType = CustomPropertyMapping.buildMapping(getTaskManager());
-    for (Entry<CustomPropertyDefinition, FieldType> e : customProperty_fieldType.entrySet()) {
-      myOutputProject.getCustomFields().getCustomField(e.getValue()).setAlias(e.getKey().getName());
-    }
+    exportCustomFieldTypes(customProperty_fieldType);
     net.sf.mpxj.Task rootTask = myOutputProject.addTask();
     rootTask.setEffortDriven(false);
     rootTask.setID(0);
@@ -304,11 +302,20 @@ class ProjectFileExporter {
 
   private void exportResources(Map<Integer, Resource> id2mpxjResource) throws MPXJException {
     Map<CustomPropertyDefinition, FieldType> customProperty_fieldType = CustomPropertyMapping.buildMapping(getResourceManager());
-    for (Entry<CustomPropertyDefinition, FieldType> e : customProperty_fieldType.entrySet()) {
-      myOutputProject.getCustomFields().getCustomField(e.getValue()).setAlias(e.getKey().getName());
-    }
+    exportCustomFieldTypes(customProperty_fieldType);
     for (HumanResource hr : getResourceManager().getResources()) {
       exportResource(hr, id2mpxjResource, customProperty_fieldType);
+    }
+  }
+
+  private void exportCustomFieldTypes(Map<CustomPropertyDefinition, FieldType> customProperty_fieldType) {
+    for (Entry<CustomPropertyDefinition, FieldType> e : customProperty_fieldType.entrySet()) {
+      String alias = e.getKey().getName();
+      if ("".equals(alias.trim())) {
+        alias = e.getValue().getName();
+
+      }
+      myOutputProject.getCustomFields().getCustomField(e.getValue()).setAlias(alias);
     }
   }
 

--- a/ganttproject/src/net/sourceforge/ganttproject/gui/EditableList.java
+++ b/ganttproject/src/net/sourceforge/ganttproject/gui/EditableList.java
@@ -18,20 +18,18 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 package net.sourceforge.ganttproject.gui;
 
-import java.awt.BorderLayout;
-import java.awt.Component;
-import java.awt.Rectangle;
-import java.awt.event.MouseEvent;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
+import biz.ganttproject.core.option.ValidationException;
+import net.sourceforge.ganttproject.language.GanttLanguage;
 
 import javax.swing.*;
 import javax.swing.table.AbstractTableModel;
 import javax.swing.table.DefaultTableCellRenderer;
 import javax.swing.table.TableColumn;
-
-import net.sourceforge.ganttproject.language.GanttLanguage;
+import java.awt.*;
+import java.awt.event.MouseEvent;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 public abstract class EditableList<T> {
 
@@ -158,6 +156,17 @@ public abstract class EditableList<T> {
           return super.getCellEditorValue();
         }
 
+        @Override
+        public boolean stopCellEditing() {
+          try {
+            boolean result = super.stopCellEditing();
+            getComponent().setBackground(UIUtil.getValidFieldColor());
+            return result;
+          } catch (ValidationException e) {
+            getComponent().setBackground(UIUtil.ERROR_BACKGROUND);
+            return false;
+          }
+        }
       });
       if (!myPossibleValues.isEmpty()) {
         setupEditor(myPossibleValues, resourcesTable);

--- a/ganttproject/src/net/sourceforge/ganttproject/gui/tableView/ColumnManagerPanel.java
+++ b/ganttproject/src/net/sourceforge/ganttproject/gui/tableView/ColumnManagerPanel.java
@@ -25,6 +25,7 @@ import biz.ganttproject.core.option.DefaultEnumerationOption;
 import biz.ganttproject.core.option.DefaultStringOption;
 import biz.ganttproject.core.option.GPOption;
 import biz.ganttproject.core.option.GPOptionGroup;
+import biz.ganttproject.core.option.ValidationException;
 import biz.ganttproject.core.table.ColumnList;
 import biz.ganttproject.core.table.ColumnList.Column;
 import com.google.common.base.Function;
@@ -108,6 +109,9 @@ public class ColumnManagerPanel {
 
       @Override
       protected CustomPropertyDefinition createPrototype(Object editValue) {
+        if ("".equals(String.valueOf(editValue).trim())) {
+          throw new ValidationException("Please type column name");
+        }
         return new DefaultCustomPropertyDefinition(String.valueOf(editValue));
       }
 


### PR DESCRIPTION
Prevent empty names in the UI and use non-empty replacement in the exporter.