### PR TITLE
Show user teams in GP Cloud Storage UI

### DIFF
--- a/ganttproject-builder/build.gradle
+++ b/ganttproject-builder/build.gradle
@@ -56,6 +56,7 @@ allprojects {
     libDir = 'lib'
     mvnDir = 'lib/mvn'
   }
+  sourceCompatibility = 1.8
   targetCompatibility = 1.8
 
   task updateMavenDeps(type: Copy) {

--- a/ganttproject/src/biz/ganttproject/storage/BrowserPaneBuilder.kt
+++ b/ganttproject/src/biz/ganttproject/storage/BrowserPaneBuilder.kt
@@ -1,0 +1,109 @@
+/*
+Copyright 2018 BarD Software s.r.o
+
+This file is part of GanttProject, an opensource project management tool.
+
+GanttProject is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+GanttProject is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with GanttProject.  If not, see <http://www.gnu.org/licenses/>.
+*/
+package biz.ganttproject.storage
+
+import biz.ganttproject.lib.fx.VBoxBuilder
+import javafx.beans.property.SimpleBooleanProperty
+import javafx.collections.ObservableList
+import javafx.scene.control.Button
+import javafx.scene.layout.HBox
+import javafx.scene.layout.Pane
+import javafx.scene.layout.Priority
+import net.sourceforge.ganttproject.language.GanttLanguage
+import org.controlsfx.control.StatusBar
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.util.function.Consumer
+
+/**
+ * This function takes path and loads path contents from the storage.
+ * It should use "loading" callback to show or hide progress bar and
+ * "success" callback to show created list of FolderItem elements in the UI.
+ *
+ * This function is supposed to run asynchronously in a background task.
+ */
+typealias Loader = (path: Path, success: Consumer<ObservableList<FolderItem>>, loading: Consumer<Boolean>) -> Unit
+
+data class BrowserPaneElements(val breadcrumbView: BreadcrumbView,
+                               val listView: FolderView<FolderItem>,
+                               val pane: Pane)
+
+/**
+ * Builds browser pane UI from elements: breadcrumbs, list view, action button
+ * and status bar with customization options.
+ *
+ * @author dbarashev@bardsoftware.com
+ */
+class BrowserPaneBuilder(
+    private val mode: StorageDialogBuilder.Mode,
+    private val dialogUi: StorageDialogBuilder.DialogUi,
+    private val loader: Loader) {
+  private val i18n = GanttLanguage.getInstance()
+  private val rootPane = VBoxBuilder("pane-service-contents")
+
+  private lateinit var listView: FolderView<FolderItem>
+  private val busyIndicator = StatusBar().apply {
+    text = ""
+    HBox.setHgrow(this, Priority.ALWAYS)
+  }
+  private lateinit var breadcrumbView: BreadcrumbView
+  private lateinit var saveBox: HBox
+
+  fun withListView() {
+    this.listView = FolderView(
+        this.dialogUi,
+        Consumer { },
+        Consumer { },
+        SimpleBooleanProperty(true),
+        SimpleBooleanProperty(true))
+  }
+
+  fun withBreadcrumbs() {
+    val onSelectCrumb = Consumer { path: Path ->
+      loader(path,
+          Consumer { items -> this.listView.setResources(items) },
+          Consumer { busyIndicator.progress = if (it) -1.0 else 0.0 }
+      )
+    }
+
+    this.breadcrumbView = BreadcrumbView(Paths.get("/", "GanttProject Cloud"), onSelectCrumb)
+  }
+
+  fun withActionButton() {
+    val btnSave = Button(i18n.getText("storageService.local.${this.mode.name.toLowerCase()}.actionLabel"))
+    btnSave.styleClass.add("btn-attention")
+    this.saveBox = HBox().apply {
+      children.addAll(busyIndicator, btnSave)
+      styleClass.add("doclist-save-box")
+    }
+  }
+
+  fun build(): BrowserPaneElements {
+    rootPane.apply {
+      vbox.prefWidth = 400.0
+      addTitle(String.format("webdav.ui.title.%s",
+          this@BrowserPaneBuilder.mode.name.toLowerCase()),
+          "GanttProject Cloud")
+      add(breadcrumbView.breadcrumbs)
+      add(listView.listView, alignment = null, growth = Priority.ALWAYS)
+      add(saveBox)
+    }
+    return BrowserPaneElements(breadcrumbView, listView, rootPane.vbox)
+  }
+}

--- a/ganttproject/src/biz/ganttproject/storage/FolderView.kt
+++ b/ganttproject/src/biz/ganttproject/storage/FolderView.kt
@@ -10,10 +10,7 @@ package biz.ganttproject.storage
 import de.jensd.fx.glyphs.fontawesome.FontAwesomeIcon
 import de.jensd.fx.glyphs.fontawesome.FontAwesomeIconView
 import javafx.beans.Observable
-import javafx.beans.property.BooleanProperty
-import javafx.beans.property.ObjectProperty
-import javafx.beans.property.SimpleBooleanProperty
-import javafx.beans.property.SimpleObjectProperty
+import javafx.beans.property.*
 import javafx.collections.FXCollections
 import javafx.collections.ListChangeListener
 import javafx.collections.ObservableList
@@ -48,15 +45,16 @@ interface FolderItem {
 /**
  * Encapsulates a list view showing the contents of a single folder.
  */
-class FolderView<T: FolderItem>(
+class FolderView<T : FolderItem>(
     val myDialogUi: StorageDialogBuilder.DialogUi,
     onDeleteResource: Consumer<T>,
     onToggleLockResource: Consumer<T>,
     isLockingSupported: BooleanProperty,
-    isDeleteSupported: BooleanProperty) {
+    isDeleteSupported: ReadOnlyBooleanProperty) {
 
   var myContents: ObservableList<T> = FXCollections.emptyObservableList()
   val listView: ListView<ListViewItem<T>> = ListView()
+
   init {
     listView.setCellFactory { _ ->
       createListCell(myDialogUi, onDeleteResource, onToggleLockResource, isLockingSupported, isDeleteSupported)
@@ -82,7 +80,7 @@ class FolderView<T: FolderItem>(
   private fun reloadItems(folderContents: ObservableList<T>) {
     val items = FXCollections.observableArrayList(createExtractor<T>())
     folderContents.stream()
-        .map({resource -> ListViewItem(resource) })
+        .map({ resource -> ListViewItem(resource) })
         .forEach({ items.add(it) })
     listView.items = items
   }
@@ -119,7 +117,7 @@ class FolderView<T: FolderItem>(
   }
 }
 
-class ListViewItem<T:FolderItem>(resource: T) {
+class ListViewItem<T : FolderItem>(resource: T) {
   val isSelected: BooleanProperty = SimpleBooleanProperty()
   val resource: ObjectProperty<T>
 
@@ -128,7 +126,7 @@ class ListViewItem<T:FolderItem>(resource: T) {
   }
 }
 
-fun <T: FolderItem> createExtractor() : Callback<ListViewItem<T>, Array<Observable>> {
+fun <T : FolderItem> createExtractor(): Callback<ListViewItem<T>, Array<Observable>> {
   return Callback { item ->
     item?.let {
       arrayOf(
@@ -137,12 +135,12 @@ fun <T: FolderItem> createExtractor() : Callback<ListViewItem<T>, Array<Observab
   }
 }
 
-fun <T: FolderItem> createListCell(
+fun <T : FolderItem> createListCell(
     dialogUi: StorageDialogBuilder.DialogUi,
     onDeleteResource: Consumer<T>,
     onToggleLockResource: Consumer<T>,
     isLockingSupported: BooleanProperty,
-    isDeleteSupported: BooleanProperty) : ListCell<ListViewItem<T>> {
+    isDeleteSupported: ReadOnlyBooleanProperty): ListCell<ListViewItem<T>> {
   return object : ListCell<ListViewItem<T>>() {
     override fun updateItem(item: ListViewItem<T>?, empty: Boolean) {
       try {
@@ -272,11 +270,11 @@ class BreadcrumbView(initialPath: Path, val onSelectCrumb: Consumer<Path>) {
 
 }
 
-fun <T: FolderItem> connect(
+fun <T : FolderItem> connect(
     filename: TextField, listView: FolderView<T>, breadcrumbView: BreadcrumbView,
     selectItem: (withEnter: Boolean, withControl: Boolean) -> Unit,
     onFilenameEnter: () -> Unit) {
-  listView.listView.onMouseClicked = EventHandler{ evt ->
+  listView.listView.onMouseClicked = EventHandler { evt ->
     val dblClick = evt.clickCount == 2
     selectItem(dblClick, dblClick)
   }
@@ -297,7 +295,8 @@ fun <T: FolderItem> connect(
       KeyCode.BACK_SPACE -> {
         breadcrumbView.pop()
       }
-      else -> {}
+      else -> {
+      }
     }
   }
 
@@ -314,7 +313,8 @@ fun <T: FolderItem> connect(
       KeyCode.ENTER -> {
         onFilenameEnter()
       }
-      else -> {}
+      else -> {
+      }
     }
   }
 }

--- a/ganttproject/src/biz/ganttproject/storage/cloud/GPCloudBrowserPane.kt
+++ b/ganttproject/src/biz/ganttproject/storage/cloud/GPCloudBrowserPane.kt
@@ -24,15 +24,7 @@ import biz.ganttproject.storage.StorageDialogBuilder
 import javafx.beans.property.SimpleBooleanProperty
 import javafx.scene.layout.Pane
 import javafx.scene.layout.Priority
-import org.apache.http.HttpHost
-import org.apache.http.auth.AuthScope
-import org.apache.http.auth.UsernamePasswordCredentials
 import org.apache.http.client.methods.HttpGet
-import org.apache.http.client.protocol.ClientContext
-import org.apache.http.impl.auth.BasicScheme
-import org.apache.http.impl.client.BasicAuthCache
-import org.apache.http.impl.client.DefaultHttpClient
-import org.apache.http.protocol.BasicHttpContext
 import org.apache.http.util.EntityUtils
 import java.util.function.Consumer
 
@@ -65,18 +57,10 @@ class GPCloudBrowserPane(
   }
 
   fun loadTeams() {
-    val httpHost = HttpHost(GPCLOUD_HOST, 443, "https")
-    val httpClient = DefaultHttpClient()
-    httpClient.credentialsProvider.setCredentials(
-        AuthScope(httpHost), UsernamePasswordCredentials(GPCloudOptions.userId.value, GPCloudOptions.authToken.value))
-    val authCache = BasicAuthCache()
-    authCache.put(httpHost, BasicScheme())
-    val context = BasicHttpContext()
-    context.setAttribute(ClientContext.AUTH_CACHE, authCache)
-
+    val http = HttpClientBuilder.buildHttpClient()
     val teamList = HttpGet("/team/list")
-    val resp = httpClient.execute(httpHost, teamList, context)
+    val resp = http.client.execute(http.host, teamList, http.context)
     println("Response code=${resp.statusLine.statusCode} reason=${resp.statusLine.reasonPhrase}")
-    EntityUtils.consume(resp.entity)
+    println(EntityUtils.toString(resp.entity))
   }
 }

--- a/ganttproject/src/biz/ganttproject/storage/cloud/GPCloudBrowserPane.kt
+++ b/ganttproject/src/biz/ganttproject/storage/cloud/GPCloudBrowserPane.kt
@@ -19,6 +19,7 @@ along with GanttProject.  If not, see <http://www.gnu.org/licenses/>.
 package biz.ganttproject.storage.cloud
 
 import biz.ganttproject.lib.fx.VBoxBuilder
+import biz.ganttproject.storage.BreadcrumbView
 import biz.ganttproject.storage.FolderItem
 import biz.ganttproject.storage.FolderView
 import biz.ganttproject.storage.StorageDialogBuilder
@@ -27,10 +28,15 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.node.ArrayNode
 import javafx.beans.property.SimpleBooleanProperty
 import javafx.collections.FXCollections
+import javafx.scene.control.Button
+import javafx.scene.layout.HBox
 import javafx.scene.layout.Pane
 import javafx.scene.layout.Priority
+import net.sourceforge.ganttproject.language.GanttLanguage
 import org.apache.http.client.methods.HttpGet
 import org.apache.http.util.EntityUtils
+import org.controlsfx.control.StatusBar
+import java.nio.file.Paths
 import java.util.function.Consumer
 
 /**
@@ -42,6 +48,7 @@ import java.util.function.Consumer
 class GPCloudBrowserPane(
     val mode: StorageDialogBuilder.Mode,
     val dialogUi: StorageDialogBuilder.DialogUi) {
+  private val i18n = GanttLanguage.getInstance()
   private lateinit var listView: FolderView<FolderItem>
 
   fun createStorageUi(): Pane {
@@ -53,12 +60,28 @@ class GPCloudBrowserPane(
         SimpleBooleanProperty(true),
         SimpleBooleanProperty(true))
 
+    val breadcrumbView = BreadcrumbView(Paths.get("/", "GanttProject Cloud"), Consumer {})
+
+    val busyIndicator = StatusBar().apply {
+      styleClass.add("notification")
+      text = ""
+    }
+    HBox.setHgrow(busyIndicator, Priority.ALWAYS)
+    val btnSave = Button(i18n.getText("storageService.local.${this.mode.name.toLowerCase()}.actionLabel"))
+    btnSave.styleClass.add("btn-attention")
+    val saveBox = HBox().apply {
+      children.addAll(busyIndicator, btnSave)
+      styleClass.add("doclist-save-box")
+    }
+
     rootPane.apply {
       vbox.prefWidth = 400.0
       addTitle(String.format("webdav.ui.title.%s",
           this@GPCloudBrowserPane.mode.name.toLowerCase()),
           "GanttProject Cloud")
+      add(breadcrumbView.breadcrumbs)
       add(listView.listView, alignment = null, growth = Priority.ALWAYS)
+      add(saveBox)
     }
     return rootPane.vbox
   }

--- a/ganttproject/src/biz/ganttproject/storage/cloud/GPCloudBrowserPane.kt
+++ b/ganttproject/src/biz/ganttproject/storage/cloud/GPCloudBrowserPane.kt
@@ -76,7 +76,7 @@ class GPCloudBrowserPane(
     }
     val browserPaneElements = builder.apply {
       withBreadcrumbs()
-      withActionButton()
+      withActionButton(EventHandler {})
       withListView()
     }.build()
 
@@ -126,7 +126,7 @@ class LoaderService(private val dialogUi: StorageDialogBuilder.DialogUi) : Servi
   }
 }
 
-// Task implementation which does the real work: sends HTTP request
+// Implementation of a task which does the real work: sends HTTP request
 // and interprets the results.
 class LoaderTask : Task<ObservableList<FolderItem>>() {
   override fun call(): ObservableList<FolderItem>? {

--- a/ganttproject/src/biz/ganttproject/storage/cloud/GPCloudBrowserPane.kt
+++ b/ganttproject/src/biz/ganttproject/storage/cloud/GPCloudBrowserPane.kt
@@ -24,6 +24,16 @@ import biz.ganttproject.storage.StorageDialogBuilder
 import javafx.beans.property.SimpleBooleanProperty
 import javafx.scene.layout.Pane
 import javafx.scene.layout.Priority
+import org.apache.http.HttpHost
+import org.apache.http.auth.AuthScope
+import org.apache.http.auth.UsernamePasswordCredentials
+import org.apache.http.client.methods.HttpGet
+import org.apache.http.client.protocol.ClientContext
+import org.apache.http.impl.auth.BasicScheme
+import org.apache.http.impl.client.BasicAuthCache
+import org.apache.http.impl.client.DefaultHttpClient
+import org.apache.http.protocol.BasicHttpContext
+import org.apache.http.util.EntityUtils
 import java.util.function.Consumer
 
 /**
@@ -52,5 +62,21 @@ class GPCloudBrowserPane(
       add(listView.listView, alignment = null, growth = Priority.ALWAYS)
     }
     return rootPane.vbox
+  }
+
+  fun loadTeams() {
+    val httpHost = HttpHost(GPCLOUD_HOST, 443, "https")
+    val httpClient = DefaultHttpClient()
+    httpClient.credentialsProvider.setCredentials(
+        AuthScope(httpHost), UsernamePasswordCredentials(GPCloudOptions.userId.value, GPCloudOptions.authToken.value))
+    val authCache = BasicAuthCache()
+    authCache.put(httpHost, BasicScheme())
+    val context = BasicHttpContext()
+    context.setAttribute(ClientContext.AUTH_CACHE, authCache)
+
+    val teamList = HttpGet("/team/list")
+    val resp = httpClient.execute(httpHost, teamList, context)
+    println("Response code=${resp.statusLine.statusCode} reason=${resp.statusLine.reasonPhrase}")
+    EntityUtils.consume(resp.entity)
   }
 }

--- a/ganttproject/src/biz/ganttproject/storage/cloud/GPCloudStorage.kt
+++ b/ganttproject/src/biz/ganttproject/storage/cloud/GPCloudStorage.kt
@@ -33,6 +33,7 @@ import java.util.*
 import java.util.concurrent.CompletableFuture
 import java.util.function.Consumer
 
+val GPCLOUD_HOST = "cloud.ganttproject.biz"
 val GPCLOUD_LANDING_URL = "https://cloud.ganttproject.biz"
 val GPCLOUD_SIGNIN_URL = "https://cloud.ganttproject.biz/__/auth/desktop"
 val GPCLOUD_SIGNUP_URL = "https://cloud.ganttproject.biz/__/auth/handler"
@@ -90,6 +91,7 @@ class GPCloudStorage(
         this.userId.value = userId
       }
       nextPage(browserPane.createStorageUi())
+      browserPane.loadTeams()
     }
 
     val signupPane = GPCloudSignupPane(onTokenCallback)

--- a/ganttproject/src/biz/ganttproject/storage/cloud/GPCloudStorage.kt
+++ b/ganttproject/src/biz/ganttproject/storage/cloud/GPCloudStorage.kt
@@ -50,6 +50,7 @@ import java.util.concurrent.CompletableFuture
 import java.util.function.Consumer
 
 val GPCLOUD_HOST = "cumulus-dot-ganttproject-cloud.appspot.com"
+val GPCLOUD_ORIGIN = "https://$GPCLOUD_HOST"
 val GPCLOUD_LANDING_URL = "https://$GPCLOUD_HOST"
 val GPCLOUD_SIGNIN_URL = "https://$GPCLOUD_HOST/__/auth/desktop"
 val GPCLOUD_SIGNUP_URL = "https://$GPCLOUD_HOST/__/auth/handler"
@@ -168,7 +169,9 @@ class HttpServerImpl : NanoHTTPD("localhost", 0) {
     val validity = getParam(session, "validity")
 
     onTokenReceived?.invoke(token, validity, userId)
-    return newFixedLengthResponse("")
+    val resp = newFixedLengthResponse("")
+    resp.addHeader("Access-Control-Allow-Origin", "$GPCLOUD_ORIGIN")
+    return resp
   }
 }
 

--- a/ganttproject/src/biz/ganttproject/storage/cloud/GPCloudStorage.kt
+++ b/ganttproject/src/biz/ganttproject/storage/cloud/GPCloudStorage.kt
@@ -108,7 +108,6 @@ class GPCloudStorage(
       }
       Platform.runLater {
         nextPage(browserPane.createStorageUi())
-        browserPane.loadTeams()
       }
     }
 

--- a/ganttproject/src/biz/ganttproject/storage/cloud/GPCloudStorage.kt
+++ b/ganttproject/src/biz/ganttproject/storage/cloud/GPCloudStorage.kt
@@ -22,6 +22,7 @@ import biz.ganttproject.FXUtil
 import biz.ganttproject.core.option.*
 import biz.ganttproject.storage.StorageDialogBuilder
 import fi.iki.elonen.NanoHTTPD
+import javafx.application.Platform
 import javafx.event.ActionEvent
 import javafx.event.EventHandler
 import javafx.scene.control.Label
@@ -48,10 +49,10 @@ import java.util.*
 import java.util.concurrent.CompletableFuture
 import java.util.function.Consumer
 
-val GPCLOUD_HOST = "cloud.ganttproject.biz"
-val GPCLOUD_LANDING_URL = "https://cloud.ganttproject.biz"
-val GPCLOUD_SIGNIN_URL = "https://cloud.ganttproject.biz/__/auth/desktop"
-val GPCLOUD_SIGNUP_URL = "https://cloud.ganttproject.biz/__/auth/handler"
+val GPCLOUD_HOST = "cumulus-dot-ganttproject-cloud.appspot.com"
+val GPCLOUD_LANDING_URL = "https://$GPCLOUD_HOST"
+val GPCLOUD_SIGNIN_URL = "https://$GPCLOUD_HOST/__/auth/desktop"
+val GPCLOUD_SIGNUP_URL = "https://$GPCLOUD_HOST/__/auth/handler"
 
 /**
  * @author dbarashev@bardsoftware.com
@@ -105,8 +106,10 @@ class GPCloudStorage(
         this.validity.value = validity?.toIntOrNull()
         this.userId.value = userId
       }
-      nextPage(browserPane.createStorageUi())
-      browserPane.loadTeams()
+      Platform.runLater {
+        nextPage(browserPane.createStorageUi())
+        browserPane.loadTeams()
+      }
     }
 
     val signupPane = GPCloudSignupPane(onTokenCallback)


### PR DESCRIPTION
This change makes the UI of GanttProject Cloud storage mostly matching the UI of WebDAV storage. They both use the same UI layout and controls. Currently we can only show the teams where current use is a member of.