### PR TITLE
Quicker assignment of tasks to resources

### DIFF
--- a/ganttproject/src/net/sourceforge/ganttproject/GanttTree2.java
+++ b/ganttproject/src/net/sourceforge/ganttproject/GanttTree2.java
@@ -23,12 +23,15 @@ import com.google.common.base.Predicate;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import net.sourceforge.ganttproject.action.GPAction;
+import net.sourceforge.ganttproject.action.resource.AssignmentToggleAction;
 import net.sourceforge.ganttproject.action.task.*;
 import net.sourceforge.ganttproject.chart.Chart;
 import net.sourceforge.ganttproject.chart.VisibleNodesFilter;
 import net.sourceforge.ganttproject.chart.overview.ToolbarBuilder;
 import net.sourceforge.ganttproject.gui.TaskTreeUIFacade;
 import net.sourceforge.ganttproject.gui.UIFacade;
+import net.sourceforge.ganttproject.resource.HumanResource;
+import net.sourceforge.ganttproject.task.ResourceAssignment;
 import net.sourceforge.ganttproject.task.Task;
 import net.sourceforge.ganttproject.task.TaskManager;
 import net.sourceforge.ganttproject.task.TaskNode;
@@ -297,8 +300,34 @@ public class GanttTree2 extends TreeTableContainer<Task, GanttTreeTable, GanttTr
       actions.add(getDeleteAction());
       actions.add(null);
       actions.add(getTreeTable().getManageColumnsAction());
+      actions.add(null);
+
+      addHumanResourcesSubmenu(actions);
     }
     return actions.toArray(new Action[0]);
+  }
+
+  private void addHumanResourcesSubmenu(List<Action> actions) {
+    // TODO: enable when multiple tasks are selected
+    if (getTaskSelectionManager().getSelectedTasks().size() == 1) {
+      Task task = getTaskSelectionManager().getSelectedTasks().get(0);
+      List<HumanResource> resources = myProject.getHumanResourceManager().getResources();
+
+      HashMap<HumanResource, AssignmentToggleAction> human2action = new HashMap<>();
+
+      for (HumanResource hr : resources) {
+        AssignmentToggleAction assignmentAction = new AssignmentToggleAction(hr, task, myUIFacade);
+        assignmentAction.putValue(Action.SELECTED_KEY, false);
+        human2action.put(hr, assignmentAction);
+        actions.add(assignmentAction);
+      }
+
+      ResourceAssignment[] assignments = task.getAssignmentCollection().getAssignments();
+      for (ResourceAssignment ra : assignments) {
+        AssignmentToggleAction assignmentAction = human2action.get(ra.getResource());
+        assignmentAction.putValue(Action.SELECTED_KEY, true);
+      }
+    }
   }
 
   /** Create a popup menu when mouse click */

--- a/ganttproject/src/net/sourceforge/ganttproject/UIFacadeImpl.java
+++ b/ganttproject/src/net/sourceforge/ganttproject/UIFacadeImpl.java
@@ -39,6 +39,7 @@ import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import net.sourceforge.ganttproject.action.resource.AssignmentToggleAction;
 import net.sourceforge.ganttproject.action.zoom.ZoomActionSet;
 import net.sourceforge.ganttproject.chart.Chart;
 import net.sourceforge.ganttproject.chart.GanttChart;
@@ -305,9 +306,17 @@ class UIFacadeImpl extends ProgressProvider implements UIFacade {
   @Override
   public void showPopupMenu(Component invoker, Collection<Action> actions, int x, int y) {
     JPopupMenu menu = new JPopupMenu();
+
+    // TODO: refactor code so that submenus could be added in more generic way
+    String assignTo = GanttLanguage.getInstance().getText("assignments");
+    JMenu resourcesMenu = new JMenu(assignTo);
+
     for (Action action : actions) {
       if (action == null) {
         menu.addSeparator();
+      } else if (AssignmentToggleAction.class.equals(action.getClass())){
+        resourcesMenu.add(new JCheckBoxMenuItem(action));
+        continue;
       } else {
         Boolean isSelected = (Boolean) action.getValue(Action.SELECTED_KEY);
         if (isSelected == null) {
@@ -317,6 +326,11 @@ class UIFacadeImpl extends ProgressProvider implements UIFacade {
         }
       }
     }
+
+    if (resourcesMenu.getItemCount() > 0) {
+      menu.add(resourcesMenu);
+    }
+
     menu.applyComponentOrientation(getLanguage().getComponentOrientation());
     menu.show(invoker, x, y);
   }

--- a/ganttproject/src/net/sourceforge/ganttproject/action/resource/AssignmentToggleAction.java
+++ b/ganttproject/src/net/sourceforge/ganttproject/action/resource/AssignmentToggleAction.java
@@ -1,0 +1,74 @@
+/*
+Copyright 2019 BarD Software s.r.o, Juanan Pereira
+
+This file is part of GanttProject, an opensource project management tool.
+
+GanttProject is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+GanttProject is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with GanttProject.  If not, see <http://www.gnu.org/licenses/>.
+*/
+package net.sourceforge.ganttproject.action.resource;
+
+import net.sourceforge.ganttproject.action.GPAction;
+import net.sourceforge.ganttproject.gui.UIFacade;
+import net.sourceforge.ganttproject.resource.HumanResource;
+import net.sourceforge.ganttproject.task.ResourceAssignment;
+import net.sourceforge.ganttproject.task.ResourceAssignmentMutator;
+import net.sourceforge.ganttproject.task.Task;
+
+import javax.swing.*;
+import java.awt.event.ActionEvent;
+
+
+/**
+ * Action that adds/removes the assignment of a task to a resource
+ */
+public class AssignmentToggleAction extends GPAction {
+  private final HumanResource myHumanResource;
+  private final Task myTask;
+  private final UIFacade myUIFacade;
+
+  public AssignmentToggleAction(HumanResource hr, Task task, UIFacade uiFacade) {
+    super(hr.getName(), IconSize.TOOLBAR_SMALL);
+    myHumanResource = hr;
+    myTask = task;
+    myUIFacade = uiFacade;
+  }
+
+  private void createAssignment() {
+    ResourceAssignmentMutator mutator = myTask.getAssignmentCollection().createMutator();
+    ResourceAssignment newAssignment = mutator.addAssignment(myHumanResource);
+    newAssignment.setLoad(100);
+    newAssignment.setRoleForAssignment(newAssignment.getResource().getRole());
+    mutator.commit();
+  }
+
+  public void delete(HumanResource hr) {
+    ResourceAssignmentMutator mutator = myTask.getAssignmentCollection().createMutator();
+    mutator.deleteAssignment(hr);
+    mutator.commit();
+  }
+
+  @Override
+  public void actionPerformed(ActionEvent e) {
+    myUIFacade.getUndoManager().undoableEdit(getLocalizedDescription(), new Runnable() {
+      @Override
+      public void run() {
+        if (getValue(Action.SELECTED_KEY) == Boolean.TRUE) {
+          createAssignment();
+        } else {
+          delete(myHumanResource);
+        }
+      }
+    });
+  }
+}


### PR DESCRIPTION
Fixes #1669

When the user selects a task and opens the contextual menu, this patch will show a submenu of human resources that can be (un)assigned to that single task. For the time being, quick assignment of multiple tasks is not supported but if needed, I'd like to discuss how to implement that also.