### PR TITLE
Avoid NPE when entering url/username/password in webdav settings.

### DIFF
--- a/ganttproject/src/net/sourceforge/ganttproject/document/webdav/WebDavOptionPageProvider.java
+++ b/ganttproject/src/net/sourceforge/ganttproject/document/webdav/WebDavOptionPageProvider.java
@@ -90,7 +90,9 @@ public class WebDavOptionPageProvider extends OptionPageProviderBase {
     urlOption.addChangeValueListener(new ChangeValueListener() {
       @Override
       public void changeValue(ChangeValueEvent event) {
-        serverList.getSelectedObject().setRootUrl(urlOption.getValue());
+        if (serverList.getSelectedObject() != null) {
+          serverList.getSelectedObject().setRootUrl(urlOption.getValue());
+        }
       }
     });
 
@@ -98,7 +100,9 @@ public class WebDavOptionPageProvider extends OptionPageProviderBase {
     usernameOption.addChangeValueListener(new ChangeValueListener() {
       @Override
       public void changeValue(ChangeValueEvent event) {
-        serverList.getSelectedObject().username = usernameOption.getValue();
+        if (serverList.getSelectedObject() != null) {
+          serverList.getSelectedObject().username = usernameOption.getValue();
+        }
       }
     });
 
@@ -106,7 +110,9 @@ public class WebDavOptionPageProvider extends OptionPageProviderBase {
     passwordOption.addChangeValueListener(new ChangeValueListener() {
       @Override
       public void changeValue(ChangeValueEvent event) {
-        serverList.getSelectedObject().password = passwordOption.getValue();
+        if (serverList.getSelectedObject() != null) {
+          serverList.getSelectedObject().password = passwordOption.getValue();
+        }
       }
     });
     passwordOption.setScreened(true);
@@ -115,7 +121,9 @@ public class WebDavOptionPageProvider extends OptionPageProviderBase {
     savePasswordOption.addChangeValueListener(new ChangeValueListener() {
       @Override
       public void changeValue(ChangeValueEvent event) {
-        serverList.getSelectedObject().savePassword = savePasswordOption.getValue();
+        if (serverList.getSelectedObject() != null) {
+          serverList.getSelectedObject().savePassword = savePasswordOption.getValue();
+        }
       }
     });
 


### PR DESCRIPTION
Refer to issue #1598

This patch just avoids the NullPointerException that arises when the user types anything in the WebDav settings (url, username, pass) before adding a new server. The usability of this panel should be improved, though. For example, as mentioned, disabling WebDav settings input controls when there isn't a selected server. 