### PR TITLE
Workaround measures for macOS PDF fonts

### DIFF
--- a/biz.ganttproject.core/src/main/java/biz/ganttproject/Logging.kt
+++ b/biz.ganttproject.core/src/main/java/biz/ganttproject/Logging.kt
@@ -18,18 +18,20 @@ along with GanttProject.  If not, see <http://www.gnu.org/licenses/>.
 */
 package biz.ganttproject
 
+import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.slf4j.MDC
 
 /**
  * @author dbarashev@bardsoftware.com
  */
-interface LoggerApi {
+interface LoggerApi<T> {
   fun error(msg: String, vararg params: Any, kv: Map<String, Any> = emptyMap(), exception: Throwable? = null)
   fun debug(msg: String, vararg params: Any, kv: Map<String, Any> = emptyMap())
+  fun delegate(): T
 }
 
-class LoggerImpl(name: String) : LoggerApi {
+class LoggerImpl(name: String) : LoggerApi<Logger> {
   private val delegate = LoggerFactory.getLogger(name)
 
   override fun error(msg: String, vararg params: Any, kv: Map<String, Any>, exception: Throwable?) {
@@ -45,5 +47,7 @@ class LoggerImpl(name: String) : LoggerApi {
     delegate.debug(msg, *params)
     MDC.clear()
   }
+
+  override fun delegate() = delegate
 
 }

--- a/ganttproject/src/main/java/net/sourceforge/ganttproject/GPLogger.java
+++ b/ganttproject/src/main/java/net/sourceforge/ganttproject/GPLogger.java
@@ -115,7 +115,7 @@ public class GPLogger {
     return logger;
   }
 
-  public static LoggerApi create(String name) { return new LoggerImpl(name); }
+  public static LoggerApi<org.slf4j.Logger> create(String name) { return new LoggerImpl(name); }
   public static Logger getLogger(Class<?> clazz) {
     return getLogger(clazz.getName());
   }

--- a/org.ganttproject.impex.htmlpdf/src/main/java/org/ganttproject/impex/htmlpdf/fonts/TTFontCache.java
+++ b/org.ganttproject.impex.htmlpdf/src/main/java/org/ganttproject/impex/htmlpdf/fonts/TTFontCache.java
@@ -40,6 +40,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Properties;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
@@ -53,10 +54,10 @@ import java.util.stream.Collectors;
  */
 public class TTFontCache {
   private static final org.slf4j.Logger ourLogger = GPLogger.create("Export.Pdf.Fonts").delegate();
-  private static String FALLBACK_FONT_PATH = "/fonts/wqy-microhei.ttc";
-  private Map<String, AwtFontSupplier> myMap_Family_RegularFont = new TreeMap<String, AwtFontSupplier>();
-  private final Map<FontKey, com.itextpdf.text.Font> myFontCache = new HashMap<FontKey, com.itextpdf.text.Font>();
-  private Map<String, Function<String, BaseFont>> myMap_Family_ItextFont = new HashMap<String, Function<String, BaseFont>>();
+  private static final String FALLBACK_FONT_PATH = "/fonts/wqy-microhei.ttc";
+  private final Map<String, AwtFontSupplier> myMap_Family_RegularFont = new TreeMap<>();
+  private final Map<FontKey, com.itextpdf.text.Font> myFontCache = new HashMap<>();
+  private final Map<String, Function<String, BaseFont>> myMap_Family_ItextFont = new HashMap<>();
   private Properties myProperties;
   private Function<String, BaseFont> myFallbackFont;
 
@@ -86,7 +87,7 @@ public class TTFontCache {
   }
 
   public List<String> getRegisteredFamilies() {
-    return new ArrayList<String>(myMap_Family_RegularFont.keySet());
+    return new ArrayList<>(myMap_Family_RegularFont.keySet());
   }
 
   public Font getAwtFont(String family) {
@@ -163,9 +164,7 @@ public class TTFontCache {
     private Font createFont(File fontFile) {
       try {
         return createAwtFont(fontFile);
-      } catch (IOException e) {
-        GPLogger.log(e);
-      } catch (FontFormatException e) {
+      } catch (IOException | FontFormatException e) {
         GPLogger.log(e);
       }
       return null;
@@ -194,7 +193,7 @@ public class TTFontCache {
   }
 
   private Function<String, BaseFont> createFontSupplier(final File fontFile, final boolean isEmbedded)
-      throws DocumentException, IOException {
+      throws DocumentException {
     Function<String, BaseFont> result = charset -> {
       try {
         if (fontFile.getName().toLowerCase().endsWith(".ttc")) {
@@ -202,10 +201,7 @@ public class TTFontCache {
         } else {
           return BaseFont.createFont(fontFile.getAbsolutePath(), charset, isEmbedded);
         }
-      } catch (DocumentException e) {
-        ourLogger.error("Failure when creating PDF font from file={} for charset={}",
-          fontFile.getName(), GanttLanguage.getInstance().getCharSet(), e);
-      } catch (IOException e) {
+      } catch (DocumentException | IOException e) {
         ourLogger.error("Failure when creating PDF font from file={} for charset={}",
           fontFile.getName(), GanttLanguage.getInstance().getCharSet(), e);
       }
@@ -225,10 +221,10 @@ public class TTFontCache {
   }
 
   private static class FontKey {
-    private String family;
-    private int style;
-    private float size;
-    private String charset;
+    private final String family;
+    private final int style;
+    private final float size;
+    private final String charset;
 
     FontKey(String family, String charset, int style, float size) {
       this.family = family;
@@ -294,7 +290,7 @@ public class TTFontCache {
 
   public FontMapper getFontMapper(final FontSubstitutionModel substitutions, final String charset) {
     return new FontMapper() {
-      private Map<Font, BaseFont> myFontCache = new HashMap<Font, BaseFont>();
+      private final Map<Font, BaseFont> myFontCache = new HashMap<>();
 
       @Override
       public BaseFont awtToPdf(Font awtFont) {
@@ -374,7 +370,7 @@ public class TTFontCache {
 
   private static String getInfo(BaseFont font) {
     return Arrays.stream(font.getFullFontName())
-      .filter(record -> record != null)
+      .filter(Objects::nonNull)
       .map(record -> String.join(", ", record))
       .collect(Collectors.toList()).toString();
   }

--- a/org.ganttproject.impex.htmlpdf/src/main/java/org/ganttproject/impex/htmlpdf/fonts/TTFontCache.java
+++ b/org.ganttproject.impex.htmlpdf/src/main/java/org/ganttproject/impex/htmlpdf/fonts/TTFontCache.java
@@ -78,7 +78,7 @@ public class TTFontCache {
 
   private void registerFonts(File dir) {
     final File[] files = dir.listFiles();
-    ourLogger.info("registerFonts: dir={] |files|={}", dir.getAbsolutePath(), files.length);
+    ourLogger.info("registerFonts: dir={} |files|={}", dir.getAbsolutePath(), files.length);
     for (File f : files) {
       if (!f.canRead()) {
         ourLogger.warn("Can't read the file={}", f.getName());
@@ -287,14 +287,18 @@ public class TTFontCache {
 
       @Override
       public BaseFont awtToPdf(Font awtFont) {
+        ourLogger.info("Searching for BaseFont for awtFont={} charset={}", awtFont, charset);
         if (myFontCache.containsKey(awtFont)) {
+          ourLogger.info("Found in cache.");
           return myFontCache.get(awtFont);
         }
 
         String family = awtFont.getFamily().toLowerCase();
         Function<String, BaseFont> f = myMap_Family_ItextFont.get(family);
+        ourLogger.info("Searching for supplier: family={} supplier={}", family, f);
         if (f != null) {
           BaseFont result = f.apply(charset);
+          ourLogger.info("created base font={}", result);
           myFontCache.put(awtFont, result);
           return result;
         }
@@ -303,17 +307,21 @@ public class TTFontCache {
         if (myProperties.containsKey("font." + family)) {
           family = String.valueOf(myProperties.get("font." + family));
         }
+        ourLogger.info("Searching for substitution. Family={}", family);
         FontSubstitution substitution = substitutions.getSubstitution(family);
         if (substitution != null) {
           family = substitution.getSubstitutionFamily();
         }
         f = myMap_Family_ItextFont.get(family);
+        ourLogger.info("substitution family={} supplier={}", family, f);
         if (f != null) {
           BaseFont result = f.apply(charset);
+          ourLogger.info("created base font={}", result);
           myFontCache.put(awtFont, result);
           return result;
         }
         BaseFont result = getFallbackFont(charset);
+        ourLogger.info("so, trying fallback font={}", result);
         if (result == null) {
           GPLogger.log(new RuntimeException("Font with family=" + awtFont.getFamily()
               + " not found. Also tried family=" + family + " and fallback font"));

--- a/org.ganttproject.impex.htmlpdf/src/main/java/org/ganttproject/impex/htmlpdf/fonts/TTFontCache.java
+++ b/org.ganttproject.impex.htmlpdf/src/main/java/org/ganttproject/impex/htmlpdf/fonts/TTFontCache.java
@@ -23,7 +23,6 @@ import com.google.common.base.Supplier;
 import com.google.common.collect.Lists;
 import com.itextpdf.awt.FontMapper;
 import com.itextpdf.text.DocumentException;
-import com.itextpdf.text.FontFactory;
 import com.itextpdf.text.pdf.BaseFont;
 import net.sourceforge.ganttproject.GPLogger;
 import net.sourceforge.ganttproject.language.GanttLanguage;
@@ -54,13 +53,11 @@ public class TTFontCache {
   private static String FALLBACK_FONT_PATH = "/fonts/LiberationSans-Regular.ttf";
   private Map<String, AwtFontSupplier> myMap_Family_RegularFont = new TreeMap<String, AwtFontSupplier>();
   private final Map<FontKey, com.itextpdf.text.Font> myFontCache = new HashMap<FontKey, com.itextpdf.text.Font>();
-//  private Map<String, Function<String, BaseFont>> myMap_Family_ItextFont = new HashMap<String, Function<String, BaseFont>>();
+  private Map<String, Function<String, BaseFont>> myMap_Family_ItextFont = new HashMap<String, Function<String, BaseFont>>();
   private Properties myProperties;
   private BaseFont myFallbackFont;
 
-
   public void registerDirectory(String path) {
-    FontFactory.registerDirectory(path, true);
     GPLogger.getLogger(getClass()).info("scanning directory=" + path);
     File dir = new File(path);
     if (dir.exists() && dir.isDirectory()) {
@@ -162,27 +159,26 @@ public class TTFontCache {
     final String family = awtFont.getFontName().toLowerCase();
     ourLogger.info("Registering font: file={} family={}", fontFile.getName(), family);
     AwtFontSupplier awtSupplier = myMap_Family_RegularFont.get(family);
-    GPLogger.getLogger(getClass()).fine("registering font: " + family);
+
+    try {
+      myMap_Family_ItextFont.put(family, createFontSupplier(fontFile, BaseFont.EMBEDDED));
+    } catch (DocumentException e) {
+      if (e.getMessage().indexOf("cannot be embedded") < 0) {
+        ourLogger.error("This font can't be embedded so we skip it", e);
+        return;
+      }
+    }
+    try {
+      myMap_Family_ItextFont.put(family, createFontSupplier(fontFile, BaseFont.NOT_EMBEDDED));
+    } catch (DocumentException e) {
+      GPLogger.logToLogger(e);
+      return;
+    }
     if (awtSupplier == null) {
       awtSupplier = new AwtFontSupplier(family);
       myMap_Family_RegularFont.put(family, awtSupplier);
     }
     awtSupplier.addFile(fontFile);
-
-//    try {
-//      myMap_Family_ItextFont.put(family, createFontSupplier(fontFile, BaseFont.EMBEDDED));
-//    } catch (DocumentException e) {
-//      if (e.getMessage().indexOf("cannot be embedded") < 0) {
-//        GPLogger.logToLogger(e);
-//        return;
-//      }
-//    }
-//    try {
-//      myMap_Family_ItextFont.put(family, createFontSupplier(fontFile, BaseFont.NOT_EMBEDDED));
-//    } catch (DocumentException e) {
-//      GPLogger.logToLogger(e);
-//      return;
-//    }
   }
 
   private Function<String, BaseFont> createFontSupplier(final File fontFile, final boolean isEmbedded)
@@ -272,15 +268,8 @@ public class TTFontCache {
     FontKey key = new FontKey(family, charset, style, size);
     com.itextpdf.text.Font result = myFontCache.get(key);
     if (result == null) {
-      //Function<String, BaseFont> f = myMap_Family_ItextFont.get(family);
-      com.itextpdf.text.Font pdfFont = FontFactory.getFont(family);
-//      if (pdfFont != null) {
-//        BaseFont result = pdfFont.getBaseFont();
-//        myFontCache.put(awtFont, result);
-//        return result;
-//      }
-
-      BaseFont bf = pdfFont == null ? getFallbackFont(charset) : pdfFont.getBaseFont();
+      Function<String, BaseFont> f = myMap_Family_ItextFont.get(family);
+      BaseFont bf = f == null ? getFallbackFont(charset) : f.apply(charset);
       if (bf != null) {
         result = new com.itextpdf.text.Font(bf, size, style);
         myFontCache.put(key, result);
@@ -305,10 +294,11 @@ public class TTFontCache {
         }
 
         String family = awtFont.getFamily().toLowerCase();
-        //Function<String, BaseFont> f = myMap_Family_ItextFont.get(family);
-        com.itextpdf.text.Font pdfFont = FontFactory.getFont(awtFont.getFontName());
-        if (pdfFont != null) {
-          BaseFont result = pdfFont.getBaseFont();
+        Function<String, BaseFont> f = myMap_Family_ItextFont.get(family);
+        ourLogger.info("Searching for supplier: family={} supplier={}", family, f);
+        if (f != null) {
+          BaseFont result = f.apply(charset);
+          ourLogger.info("created base font={}", result);
           myFontCache.put(awtFont, result);
           return result;
         }
@@ -322,20 +312,14 @@ public class TTFontCache {
         if (substitution != null) {
           family = substitution.getSubstitutionFamily();
         }
-
-        pdfFont = FontFactory.getFont(awtFont.getFontName());
-        if (pdfFont != null) {
-          BaseFont result = pdfFont.getBaseFont();
+        f = myMap_Family_ItextFont.get(family);
+        ourLogger.info("substitution family={} supplier={}", family, f);
+        if (f != null) {
+          BaseFont result = f.apply(charset);
+          ourLogger.info("created base font={}", result);
           myFontCache.put(awtFont, result);
           return result;
         }
-
-//        f = myMap_Family_ItextFont.get(family);
-//        if (f != null) {
-//          BaseFont result = f.apply(charset);
-//          myFontCache.put(awtFont, result);
-//          return result;
-//        }
         BaseFont result = getFallbackFont(charset);
         ourLogger.info("so, trying fallback font={}", result);
         if (result == null) {


### PR DESCRIPTION
1. Added more logging which can be used to trace the issues
2. Added WQY-Micro Hei font which automatically registers itself in the list of application fonts. WQY is a high-quality open-source font derived from Droid Sans Fallback  which has glyphs for lots of character sets, including CJK