### PR TITLE
Fix ganttproject bash launcher when _JAVA_OPTIONS are set

### DIFF
--- a/ganttproject-builder/ganttproject
+++ b/ganttproject-builder/ganttproject
@@ -126,7 +126,7 @@ check_java() {
     return 1
   fi
 
-  VERSION="$( $JAVA_COMMAND -version 2>&1 | head -n 1)"
+  VERSION="$( $JAVA_COMMAND -version 2>&1 | grep version | head -n 1)"
   log "...found $VERSION"
   [[ "$VERSION" =~ "11." ]] && return 0;
   [[ "$VERSION" =~ "12." ]] && return 0;


### PR DESCRIPTION
In order to have decent looking fonts (anti-aliasing) in Java GUI applications on my i3 window manager, I have a line `_JAVA_OPTIONS='-Dawt.useSystemAAFontSettings=gasp'` in my `/etc/environment`. This results in java command always displaying `Picked up _JAVA_OPTIONS: -Dawt.useSystemAAFontSettings=gasp` as first line in terminal.

Running `java -version` returns:

```
Picked up _JAVA_OPTIONS: -Dawt.useSystemAAFontSettings=gasp
openjdk version "15.0.2" 2021-01-19
OpenJDK Runtime Environment (build 15.0.2+7)
OpenJDK 64-Bit Server VM (build 15.0.2+7, mixed mode)
```

so the command `java -version 2>&1 | head -n 1` returns:

```
Picked up _JAVA_OPTIONS: -Dawt.useSystemAAFontSettings=gasp
```

instead of the line with the version.