### PR TITLE
Add a dependency on Open JavaFX (#2)

### DIFF
--- a/ganttproject/build.gradle
+++ b/ganttproject/build.gradle
@@ -8,6 +8,7 @@ buildscript {
     }
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+        classpath 'org.openjfx:javafx-plugin:0.0.9'
     }
 }
 
@@ -15,10 +16,14 @@ apply plugin: 'application'
 apply plugin: 'java'
 apply plugin: 'kotlin'
 apply plugin: 'maven-publish'
-
+apply plugin: 'org.openjfx.javafxplugin'
 
 ext {
     libDir = 'lib/core'
+}
+
+javafx {
+    modules = [ 'javafx.controls', 'javafx.fxml', 'javafx.swing' ]
 }
 
 configurations {


### PR DESCRIPTION
This commit enables the use of OpenJDK 11+ and other JDKs when compiling and
executing the project.

This commit adds a dependency to Open JavaFX, the open-source
implementation of the JavaFX API by the OpenJDK organization.