### PR TITLE
Tkt 2096 | Perform task insert on the server side

### DIFF
--- a/cloud.ganttproject.colloboque/src/main/kotlin/cloud/ganttproject/colloboque/ColloboqueServer.kt
+++ b/cloud.ganttproject.colloboque/src/main/kotlin/cloud/ganttproject/colloboque/ColloboqueServer.kt
@@ -101,7 +101,7 @@ class ColloboqueServer(
   private suspend fun processUpdatesLoop() {
     for (inputXlog in updateInputChannel) {
       try {
-        val newBaseTxnId = commitTxnIfSucc(inputXlog.projectRefid, inputXlog.baseTxnId, inputXlog.transactions[0])
+        val newBaseTxnId = applyXlog(inputXlog.projectRefid, inputXlog.baseTxnId, inputXlog.transactions[0])
           ?: continue
         val response = ServerCommitResponse(
           inputXlog.baseTxnId,
@@ -127,7 +127,7 @@ class ColloboqueServer(
    * Performs transaction commit if `baseTxnId` corresponds to the value hold by the server.
    * Returns new baseTxnId on success.
    */
-  private fun commitTxnIfSucc(projectRefid: ProjectRefid, baseTxnId: String, transaction: XlogRecord): String? {
+  private fun applyXlog(projectRefid: ProjectRefid, baseTxnId: String, transaction: XlogRecord): String? {
     if (transaction.sqlStatements.isEmpty()) throw ColloboqueServerException("Empty transactions not allowed")
     if (getBaseTxnId(projectRefid) != baseTxnId) throw ColloboqueServerException("Invalid transaction id $baseTxnId")
     try {

--- a/cloud.ganttproject.colloboque/src/main/kotlin/cloud/ganttproject/colloboque/ColloboqueServer.kt
+++ b/cloud.ganttproject.colloboque/src/main/kotlin/cloud/ganttproject/colloboque/ColloboqueServer.kt
@@ -86,7 +86,7 @@ class ColloboqueServer(
           }
           dataSourcesLock.write {
             refidToDataSource[projectRefid] = ds
-            refidToBaseTxnId[projectRefid] = ""  // TODO: get from the database
+            refidToBaseTxnId[projectRefid] = "abacaba"  // TODO: get from the database
           }
         }
       }
@@ -118,7 +118,7 @@ class ColloboqueServer(
     }
   }
 
-  private fun getBaseTxnId(projectRefid: ProjectRefid): String = dataSourcesLock.read {
+  fun getBaseTxnId(projectRefid: ProjectRefid): String = dataSourcesLock.read {
     refidToBaseTxnId[projectRefid] ?: throw ColloboqueServerException("Project $projectRefid not initialized")
   }
 

--- a/cloud.ganttproject.colloboque/src/main/kotlin/cloud/ganttproject/colloboque/DevServer.kt
+++ b/cloud.ganttproject.colloboque/src/main/kotlin/cloud/ganttproject/colloboque/DevServer.kt
@@ -81,6 +81,7 @@ class ColloboqueWebSocketServer(port: Int, private val colloboqueServer: Collobo
     init {
       handshake.parameters["projectRefid"]?.firstOrNull()?.also { refid ->
         colloboqueServer.init(refid, false)
+        this.handshakeResponse.addHeader("baseTxnId", colloboqueServer.getBaseTxnId(refid))
       }
     }
     private fun parseInputXlog(message: String): InputXlog? = try {

--- a/cloud.ganttproject.colloboque/src/main/kotlin/cloud/ganttproject/colloboque/Postgres.kt
+++ b/cloud.ganttproject.colloboque/src/main/kotlin/cloud/ganttproject/colloboque/Postgres.kt
@@ -33,6 +33,7 @@ class PostgresDataSourceFactory(
     jdbcUrl = "jdbc:postgresql://${pgHost}:${pgPort}/dev_all_projects"
   }
   private val superDataSource = HikariDataSource(superConfig)
+  private val cachedDataSources: MutableMap<ProjectRefid, DataSource> = mutableMapOf()
 
   init {
     superDataSource.connection.use {
@@ -45,6 +46,7 @@ class PostgresDataSourceFactory(
   }
 
   fun createDataSource(projectRefid: String): DataSource {
+    cachedDataSources[projectRefid]?.let { return it }
     // TODO: escape projectRefid
     val schema = "project_$projectRefid"
     superDataSource.connection.use {
@@ -60,6 +62,6 @@ class PostgresDataSourceFactory(
       password = pgSuperAuth
       jdbcUrl = "jdbc:postgresql://${pgHost}:${pgPort}/dev_all_projects"
       this.schema = schema
-    })
+    }).also { cachedDataSources[projectRefid] = it }
   }
 }

--- a/cloud.ganttproject.colloboque/src/main/resources/logback.xml
+++ b/cloud.ganttproject.colloboque/src/main/resources/logback.xml
@@ -1,7 +1,7 @@
 <configuration>
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n%rEx</pattern>
         </encoder>
     </appender>
     <root level="INFO">
@@ -10,4 +10,5 @@
     <logger name="com.zaxxer.hikari.pool.HikariPool" level="INFO"/>
     <logger name="Startup" level="INFO"/>
     <logger name="ColloboqueWebServer" level="DEBUG"/>
+    <logger name="ColloboqueServer" level="DEBUG"/>
 </configuration>

--- a/ganttproject-tester/test/net/sourceforge/ganttproject/storage/ProjectDatabaseTest.kt
+++ b/ganttproject-tester/test/net/sourceforge/ganttproject/storage/ProjectDatabaseTest.kt
@@ -54,13 +54,13 @@ class ProjectDatabaseTest {
   @BeforeEach
   private fun init() {
     dataSource = JdbcDataSource().also {
-      it.setURL("jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DATABASE_TO_LOWER=true")
+      it.setURL("jdbc:h2:mem:test$SQL_PROJECT_DATABASE_OPTIONS")
     }
     projectDatabase = SqlProjectDatabaseImpl(dataSource)
     val taskManagerBuilder = TestSetupHelper.newTaskManagerBuilder()
     taskManagerBuilder.setTaskUpdateBuilderFactory { task -> projectDatabase.createTaskUpdateBuilder(task) }
     taskManager = taskManagerBuilder.build()
-    dsl = DSL.using(dataSource, SQLDialect.H2)
+    dsl = DSL.using(dataSource, SQL_PROJECT_DATABASE_DIALECT)
   }
 
   @AfterEach

--- a/ganttproject-tester/test/net/sourceforge/ganttproject/storage/ProjectDatabaseTest.kt
+++ b/ganttproject-tester/test/net/sourceforge/ganttproject/storage/ProjectDatabaseTest.kt
@@ -54,7 +54,7 @@ class ProjectDatabaseTest {
   @BeforeEach
   private fun init() {
     dataSource = JdbcDataSource().also {
-      it.setURL("jdbc:h2:mem:test;DB_CLOSE_DELAY=-1")
+      it.setURL("jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DATABASE_TO_LOWER=true")
     }
     projectDatabase = SqlProjectDatabaseImpl(dataSource)
     val taskManagerBuilder = TestSetupHelper.newTaskManagerBuilder()

--- a/ganttproject/build.gradle
+++ b/ganttproject/build.gradle
@@ -77,6 +77,10 @@ jooq {
                                 key = 'scripts'
                                 value = 'src/main/resources/resources/sql/init-project-database.sql'
                             }
+                            property {
+                                key = 'defaultNameCase'
+                                value = 'lower'
+                            }
                         }
                     }
                     target {

--- a/ganttproject/src/main/java/biz/ganttproject/storage/cloud/GPCloudHttpImpl.kt
+++ b/ganttproject/src/main/java/biz/ganttproject/storage/cloud/GPCloudHttpImpl.kt
@@ -375,7 +375,7 @@ class WebSocketClient {
 
   // TODO: Propagate info to the client so that they could resolve conflicts.
   private fun fireCommitErrorReceived(payload: ObjectNode) {
-    LOG.debug("Commit error received:\n {}", payload)
+    LOG.error("Commit error received:\n {}", payload)
   }
 
   private fun fireBaseTxnReceived(baseTxnId: String) {

--- a/ganttproject/src/main/java/net/sourceforge/ganttproject/GanttProject.java
+++ b/ganttproject/src/main/java/net/sourceforge/ganttproject/GanttProject.java
@@ -206,6 +206,7 @@ public class GanttProject extends GanttProjectBase implements ResourceView, Gant
     if (isColloboqueLocalTest()) {
       getWebSocket().register(null);
       getWebSocket().onCommitResponseReceived(this::fireXlogReceived);
+      getWebSocket().onBaseTxnIdReceived(this::onBaseTxnIdReceived);
       var taskListenerAdapter = new TaskListenerAdapter();
       // TODO: add listeners sensibly.
       taskListenerAdapter.setTaskAddedHandler(event -> this.sendProjectStateLogs());
@@ -954,6 +955,11 @@ public class GanttProject extends GanttProjectBase implements ResourceView, Gant
 
   private Unit fireXlogReceived(ServerCommitResponse response) {
     myBaseTxnCommitInfo.update(response.getBaseTxnId(), response.getNewBaseTxnId(), 1);
+    return Unit.INSTANCE;
+  }
+
+  private Unit onBaseTxnIdReceived(String baseTxnId) {
+    myBaseTxnCommitInfo.update("", baseTxnId, 0);
     return Unit.INSTANCE;
   }
 }

--- a/ganttproject/src/main/java/net/sourceforge/ganttproject/GanttProject.java
+++ b/ganttproject/src/main/java/net/sourceforge/ganttproject/GanttProject.java
@@ -940,7 +940,7 @@ public class GanttProject extends GanttProjectBase implements ResourceView, Gant
         getWebSocket().sendLogs(new InputXlog(
           baseTxnCommitInfo.left,
           "userId",
-          "projectRefid",
+          "refid",
           logs.stream()
             .map(logRecord -> new XlogRecord(List.of(logRecord.getSqlStatement())))
             .collect(Collectors.toList())

--- a/ganttproject/src/main/java/net/sourceforge/ganttproject/storage/SqlProjectDatabaseImpl.kt
+++ b/ganttproject/src/main/java/net/sourceforge/ganttproject/storage/SqlProjectDatabaseImpl.kt
@@ -228,5 +228,5 @@ class SqlTaskUpdateBuilder(private val task: Task,
 
 private fun Task.logId(): String = "${uid}:${taskID}"
 
-private const val H2_IN_MEMORY_URL = "jdbc:h2:mem:gantt-project-state;DB_CLOSE_DELAY=-1"
+private const val H2_IN_MEMORY_URL = "jdbc:h2:mem:gantt-project-state;DB_CLOSE_DELAY=-1;DATABASE_TO_LOWER=true"
 private const val DB_INIT_SCRIPT_PATH = "/sql/init-project-database.sql"

--- a/ganttproject/src/main/java/net/sourceforge/ganttproject/storage/SqlProjectDatabaseImpl.kt
+++ b/ganttproject/src/main/java/net/sourceforge/ganttproject/storage/SqlProjectDatabaseImpl.kt
@@ -56,7 +56,7 @@ class SqlProjectDatabaseImpl(private val dataSource: DataSource) : ProjectDataba
     try {
       dataSource.connection.use { connection ->
         try {
-          val dsl = DSL.using(connection, SQLDialect.H2)
+          val dsl = DSL.using(connection, SQL_PROJECT_DATABASE_DIALECT)
           return body(dsl)
         } catch (e: Exception) {
           throw ProjectDatabaseException(errorMessage(), e)
@@ -147,7 +147,7 @@ class SqlTaskUpdateBuilder(private val task: Task,
   private var lastSetStep: UpdateSetMoreStep<TaskRecord>? = null
 
   private fun nextStep(step: (lastStep: UpdateSetStep<TaskRecord>) -> UpdateSetMoreStep<TaskRecord>) {
-    lastSetStep = step(lastSetStep ?: DSL.using(SQLDialect.H2).update(TASK))
+    lastSetStep = step(lastSetStep ?: DSL.using(SQL_PROJECT_DATABASE_DIALECT).update(TASK))
   }
 
   @Throws(ProjectDatabaseException::class)
@@ -228,5 +228,7 @@ class SqlTaskUpdateBuilder(private val task: Task,
 
 private fun Task.logId(): String = "${uid}:${taskID}"
 
-private const val H2_IN_MEMORY_URL = "jdbc:h2:mem:gantt-project-state;DB_CLOSE_DELAY=-1;DATABASE_TO_LOWER=true"
+val SQL_PROJECT_DATABASE_DIALECT = SQLDialect.POSTGRES
+const val SQL_PROJECT_DATABASE_OPTIONS = ";DB_CLOSE_DELAY=-1;DATABASE_TO_LOWER=true"
+private const val H2_IN_MEMORY_URL = "jdbc:h2:mem:gantt-project-state$SQL_PROJECT_DATABASE_OPTIONS"
 private const val DB_INIT_SCRIPT_PATH = "/sql/init-project-database.sql"

--- a/ganttproject/src/main/java/net/sourceforge/ganttproject/storage/Xlog.kt
+++ b/ganttproject/src/main/java/net/sourceforge/ganttproject/storage/Xlog.kt
@@ -70,3 +70,15 @@ data class ServerCommitResponse(
   val projectRefid: String,
   val type: String
 )
+
+/** Response from the server that signals about transaction commit failure. */
+@Serializable
+data class ServerCommitError(
+  val baseTxnId: String,
+  val projectRefid: String,
+  val message: String,
+  val type: String
+)
+
+const val SERVER_COMMIT_RESPONSE_TYPE = "ServerCommitResponse"
+const val SERVER_COMMIT_ERROR_TYPE = "ServerCommitError"


### PR DESCRIPTION
* Perform task inserts and updates on the server side if the baseTxnId matches.
* Use lower case H2 + generate lower case jOOQ, so that queries can be executed on the server side.
* During handshakes, the client sends its projectRefid. The server initializes the project and sends back the baseTxnId.
* Use Postgres dialect in the client. With H2 dialect, table qualification is added to update requests which is incompatible with Postgres.