### PR TITLE
Fix customPropertiesChange::hasChange

### DIFF
--- a/ganttproject/src/main/java/biz/ganttproject/customproperty/CustomColumnsValues.java
+++ b/ganttproject/src/main/java/biz/ganttproject/customproperty/CustomColumnsValues.java
@@ -162,12 +162,12 @@ public class CustomColumnsValues implements CustomPropertyHolder, Cloneable {
   public boolean equals(Object object) {
     if (this == object) return true;
     if (!(object instanceof CustomColumnsValues)) return false;
-    CustomColumnsValues columnsValues = (CustomColumnsValues) object;
-    return mapCustomColumnValue.equals(columnsValues.mapCustomColumnValue) && myManager.equals(columnsValues.myManager);
+    CustomColumnsValues otherColumnsValues = (CustomColumnsValues) object;
+    return mapCustomColumnValue.equals(otherColumnsValues.mapCustomColumnValue);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(mapCustomColumnValue, myManager);
+    return mapCustomColumnValue.hashCode();
   }
 }

--- a/ganttproject/src/main/java/biz/ganttproject/customproperty/CustomColumnsValues.java
+++ b/ganttproject/src/main/java/biz/ganttproject/customproperty/CustomColumnsValues.java
@@ -22,10 +22,7 @@ import biz.ganttproject.core.time.GanttCalendar;
 import net.sourceforge.ganttproject.language.GanttLanguage;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.Map.Entry;
 
 /**
@@ -159,5 +156,18 @@ public class CustomColumnsValues implements CustomPropertyHolder, Cloneable {
       }
     }
     return result;
+  }
+
+  @Override
+  public boolean equals(Object object) {
+    if (this == object) return true;
+    if (!(object instanceof CustomColumnsValues)) return false;
+    CustomColumnsValues columnsValues = (CustomColumnsValues) object;
+    return mapCustomColumnValue.equals(columnsValues.mapCustomColumnValue) && myManager.equals(columnsValues.myManager);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(mapCustomColumnValue, myManager);
   }
 }


### PR DESCRIPTION
Override `equals` for `CustomColumnsValues` to use `HashMap::equals`. It prevents from generating SQL statements for custom properties when no changes were made.