### PR TITLE
Fixes PERT chart export and printing

### DIFF
--- a/ganttproject/src/main/java/net/sourceforge/ganttproject/gui/view/ViewManagerImpl.java
+++ b/ganttproject/src/main/java/net/sourceforge/ganttproject/gui/view/ViewManagerImpl.java
@@ -58,23 +58,19 @@ public class ViewManagerImpl implements GPViewManager {
     myCutAction = new CutAction(this, undoManager);
     myPasteAction = new PasteAction(project, uiFacade, this, undoManager);
 
-    myTabs.addChangeListener(new ChangeListener() {
-
-      @Override
-      public void stateChanged(ChangeEvent e) {
-        GPView selectedView = (GPView) myTabs.getSelectedUserObject();
-        if (mySelectedView == selectedView) {
-          return;
-        }
-        if (mySelectedView != null) {
-          mySelectedView.setActive(false);
-          myViews.get(mySelectedView).setActive(false);
-        }
-        mySelectedView = selectedView;
-        mySelectedView.setActive(true);
-        myViews.get(mySelectedView).setActive(true);
-        updateActions();
+    myTabs.getModel().addChangeListener(e -> {
+      GPView selectedView = (GPView) myTabs.getSelectedUserObject();
+      if (mySelectedView == selectedView) {
+        return;
       }
+      if (mySelectedView != null) {
+        mySelectedView.setActive(false);
+        myViews.get(mySelectedView).setActive(false);
+      }
+      mySelectedView = selectedView;
+      mySelectedView.setActive(true);
+      myViews.get(mySelectedView).setActive(true);
+      updateActions();
     });
   }
 


### PR DESCRIPTION
Don't knw why, but the listener on tabs won't be called when PERT chart tab was activated. Replaced it with a listener on the model instead.

Update #2196 