### PR TITLE
Bump kotlinx-serialization to the same version as in the GanttProject

### DIFF
--- a/cloud.ganttproject.colloboque/build.gradle.kts
+++ b/cloud.ganttproject.colloboque/build.gradle.kts
@@ -41,7 +41,7 @@ dependencies {
     implementation("org.nanohttpd:nanohttpd:2.3.1")
     implementation("org.nanohttpd:nanohttpd-websocket:2.3.1")
 
-    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.3.3")
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.4.1")
 
     implementation(files("lib/eclipsito.jar"))
 


### PR DESCRIPTION
I noticed that it fixes NoClassDefFoundError in the runtime of Colloboque