### PR TITLE
PNG export improvements

### DIFF
--- a/biz.ganttproject.core/src/main/java/biz/ganttproject/core/chart/render/Style.java
+++ b/biz.ganttproject.core/src/main/java/biz/ganttproject/core/chart/render/Style.java
@@ -102,6 +102,13 @@ public class Style {
     public int getLeft() {
       return myValues.get(3);
     }
+
+    @Override
+    public String toString() {
+      return "Padding{" +
+        "myValues=" + myValues +
+        '}';
+    }
   }
 
   private static BasicStroke parseStroke(String[] components) {
@@ -174,6 +181,14 @@ public class Style {
       }
       return new Border(color, stroke);
     }
+
+    @Override
+    public String toString() {
+      return "Border{" +
+        "myStroke=" + myStroke +
+        ", myColor=" + myColor +
+        '}';
+    }
   }
 
   public static class Borders {
@@ -227,6 +242,17 @@ public class Style {
           new Border(color, myBottom.getStroke()),
           new Border(color, myRight.getStroke()));
     }
+
+    @Override
+    public String toString() {
+      return "Borders{" +
+        "myTop=" + myTop +
+        ", myLeft=" + myLeft +
+        ", myRight=" + myRight +
+        ", myBottom=" + myBottom +
+        ", isHomogeneous=" + isHomogeneous +
+        '}';
+    }
   }
 
   public static class Color {
@@ -245,6 +271,13 @@ public class Style {
         return null;
       }
       return new Color(ColorOption.Util.INSTANCE.determineColor(value));
+    }
+
+    @Override
+    public String toString() {
+      return "Color{" +
+        "myColor=" + myColor +
+        '}';
     }
   }
 
@@ -424,5 +457,20 @@ public class Style {
     }
     String value = myProperties.getProperty(myStyleName + ".opacity");
     return (value == null) ? null : Float.valueOf(value);
+  }
+
+  public String getStyleName() {
+    return myStyleName;
+  }
+
+  @Override
+  public String toString() {
+    return "Style{\n" +
+      ", myStyleName='" + myStyleName + "'\n" +
+      "myPadding=" + myPadding +
+      ", myColor=" + myColor +
+      ", myBackground=" + myBackground +
+      ", myBorders=" + myBorders +
+      '}';
   }
 }

--- a/biz.ganttproject.core/src/main/java/biz/ganttproject/core/chart/render/TextLengthCalculatorImpl.java
+++ b/biz.ganttproject.core/src/main/java/biz/ganttproject/core/chart/render/TextLengthCalculatorImpl.java
@@ -82,6 +82,13 @@ public class TextLengthCalculatorImpl implements TextMetrics {
     return myState;
   }
 
+  @Override
+  public String toString() {
+    return "TextLengthCalculatorImpl{" +
+      "myState=" + getState() +
+      '}';
+  }
+
   /** Internally used class containing unique variable for the current state */
   private static class State {
     // Internal values determining the uniqueness of the state
@@ -106,6 +113,11 @@ public class TextLengthCalculatorImpl implements TextMetrics {
     @Override
     public int hashCode() {
       return font.hashCode();
+    }
+
+    @Override
+    public String toString() {
+      return "Font=" + this.font.getFontName();
     }
   }
 }

--- a/biz.ganttproject.core/src/main/java/biz/ganttproject/core/chart/render/TextPainter.java
+++ b/biz.ganttproject.core/src/main/java/biz/ganttproject/core/chart/render/TextPainter.java
@@ -72,7 +72,7 @@ public class TextPainter extends AbstractTextPainter {
   private void paint(int xleft, int ybottom, HAlignment alignHor, VAlignment alignVer, Text text, Label label,
       Style style) {
     label.setVisible(true);
-    var font = text.getFont() == null ? myGraphics.getFont() : text.getFont().asAwtFont(myBaseFont.get().getSize2D());
+    var font = text.getFont() == null ? myGraphics.getFont() : text.getFont().asAwtFontOfSize(myBaseFont.get().getSize());
     int textHeight = font.getSize();
     Style.Padding padding = style.getPadding();
     switch (alignHor) {

--- a/biz.ganttproject.core/src/main/java/biz/ganttproject/core/table/TableSceneBuilder.kt
+++ b/biz.ganttproject.core/src/main/java/biz/ganttproject/core/table/TableSceneBuilder.kt
@@ -88,11 +88,11 @@ class TableSceneBuilder(
       ).apply {
         style = "timeline.borderBottom"
       }
-//      canvas.createLine(
-//        x + width, state.y, x + width, state.y + height
-//      ).apply {
-//        style = "timeline.borderBottom"
-//      }
+      canvas.createLine(
+        x + width.actual, state.y, x + width.actual, state.y + height
+      ).apply {
+        style = "timeline.borderBottom"
+      }
 
       // TODO: add rectangle borders and color?
       val headerAnchorX = when (config.headerAlignment) {

--- a/ganttproject/src/main/java/biz/ganttproject/lib/fx/TreeTableImageBuilder.kt
+++ b/ganttproject/src/main/java/biz/ganttproject/lib/fx/TreeTableImageBuilder.kt
@@ -58,7 +58,7 @@ fun TaskTable.buildImage(graphics2D: Graphics2D) {
 
   val visibleColumns = taskTable.columnList.exportData().filter {
     // We will not print as columns the color and notes columns: they are shown as icons in the table UI.
-    it.isVisible && TaskDefaultColumn.COLOR.stub.id != it.id && TaskDefaultColumn.NOTES.stub.id != it.id
+    it.isVisible && TaskDefaultColumn.COLOR.stub.id != it.id && TaskDefaultColumn.NOTES.stub.id != it.id && TaskDefaultColumn.INFO.stub.id != it.id
   }
   val columnMap = visibleColumns.associateWith {
     val defaultColumn = TaskDefaultColumn.find(it.id)
@@ -96,7 +96,12 @@ fun TaskTable.buildImage(graphics2D: Graphics2D) {
     columns = columnMap.values.toList(),
     items = rootSceneItems
   )
-  val painter = StyledPainterImpl(ChartUIConfiguration( taskTable.project.uIConfiguration))
+  val painter = StyledPainterImpl(ChartUIConfiguration( taskTable.project.uIConfiguration).also {
+    // Use font from the application font settings for the export.
+    val fontsize = applicationFont.value.size.roundToInt()
+    val font = applicationFontSpec.value.asAwtFontOfSize(fontsize)
+    it.setBaseFont(font, fontsize)
+  })
   painter.setGraphics(graphics2D)
 
   graphics2D.setRenderingHint(


### PR DESCRIPTION
- appropriate font from the application settings
- the same font size both when calculating text metrics and when actually drawing (that was the issue with the shift)
- draw column delimiters in the header