### PR TITLE
Reflect Ubuntu JRE package name in build.xml

### DIFF
--- a/ganttproject-builder/build.xml
+++ b/ganttproject-builder/build.xml
@@ -56,7 +56,7 @@
              homepage="https://www.ganttproject.biz/"
              section="editors"
              priority="optional"
-             depends="java17-runtime | bellsoft-java17-runtime | zulu17-jre"
+             depends="java17-runtime | bellsoft-java17-runtime | zulu17-jre | openjdk-17-jre"
              conflicts="ganttproject-praha"
              replaces="ganttproject-praha"
              postrm="${distDebWork}/postrm"


### PR DESCRIPTION
The provided .deb file in the free linux download fails to install with unresolvable dependency error.