### PR TITLE
Fix NPE on startup: DEFAULT_TRANSLATION_LOCALIZER stays DummyLocalizer when locale file exists but is missing keys

### DIFF
--- a/ganttproject/src/main/java/biz/ganttproject/app/Internationalization.kt
+++ b/ganttproject/src/main/java/biz/ganttproject/app/Internationalization.kt
@@ -29,7 +29,11 @@ private var ourLocale: Locale = Locale.getDefault()
 
 fun setLocale(locale: Locale) {
   ourLocale = locale
-  ourCurrentTranslation.value = createTranslation(locale) ?: defaultTranslation
+  // Touching defaultTranslation ensures that DEFAULT_TRANSLATION_LOCALIZER is initialized
+  // (its assignment is a side-effect of the lazy initializer). Without it, locales whose
+  // properties file is missing keys fall back to a DummyLocalizer and return null.
+  val fallback = defaultTranslation
+  ourCurrentTranslation.value = createTranslation(locale) ?: fallback
 }
 
 fun getCurrentLocale() = ourLocale


### PR DESCRIPTION
## Problem

GanttProject crashes on startup with:
```
java.lang.NullPointerException: Cannot invoke "String.length()" because "pattern" is null
    at java.text.MessageFormat.applyPattern(MessageFormat.java:469)
    at net.sourceforge.ganttproject.action.ViewToggleAction.getLocalizedDescription(ViewToggleAction.java:44)
    at net.sourceforge.ganttproject.action.GPAction.updateTooltip(GPAction.java:270)
    at biz.ganttproject.app.GanttProjectFxApp.start(GanttProjectFxApp.kt:59)
```

Any user whose UI language resolves to a locale that has its own `i18n_xx_YY.properties` file, but where that file is **missing** keys present only in the base `i18n.properties`, will hit this. Confirmed affected: `en_GB`, `en_US`, `en_AU`, `en`. The key `view.toggle.description` exists in `i18n.properties` and most non-English locale files, but not in any of the English-variant files.

Closes #2794

## Root cause

`DEFAULT_TRANSLATION_LOCALIZER` (in `InternationalizationCore.kt`) starts as `DummyLocalizer` and is only reassigned inside the `defaultTranslation` lazy initializer:

```kotlin
// InternationalizationImpl.kt
val defaultTranslation by lazy {
  (...).also {
    DEFAULT_TRANSLATION_LOCALIZER = SingleTranslationLocalizer(it)  // only runs on first access
  }
}
```

In `setLocale()`:
```kotlin
ourCurrentTranslation.value = createTranslation(locale) ?: defaultTranslation
```

When `createTranslation(locale)` succeeds (i.e. the locale file exists), the `?: defaultTranslation` branch is never evaluated, so `DEFAULT_TRANSLATION_LOCALIZER` stays as `DummyLocalizer`.

In `DefaultLocalizer.formatTextOrNull`, when a key is missing from the current locale's file, control falls through to `baseLocalizer()` which returns `DEFAULT_TRANSLATION_LOCALIZER` — still a `DummyLocalizer` — giving `null`. `ViewToggleAction.getLocalizedDescription` then passes that `null` as pattern to `MessageFormat.format`, causing the NPE.

## Fix

Evaluate `defaultTranslation` unconditionally in `setLocale()` to guarantee `DEFAULT_TRANSLATION_LOCALIZER` is initialized before any key lookup:

```kotlin
fun setLocale(locale: Locale) {
  ourLocale = locale
  // Touching defaultTranslation ensures that DEFAULT_TRANSLATION_LOCALIZER is initialized
  // (its assignment is a side-effect of the lazy initializer). Without it, locales whose
  // properties file is missing keys fall back to a DummyLocalizer and return null.
  val fallback = defaultTranslation
  ourCurrentTranslation.value = createTranslation(locale) ?: fallback
}
```

## Testing

Verified with `user.language=it`, `user.country=IT` and UI settings `ui.language=en_GB` (the original failure scenario): GanttProject now starts successfully and reaches `ProjectOpenActivityCompleted` without any exception.

Note: a more robust long-term approach would be to initialize `DEFAULT_TRANSLATION_LOCALIZER` eagerly at module load time rather than as a lazy side-effect, to avoid similar fragility in the future.