### PR TITLE
Introduce 'Document Ready' state in project open process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ dist-bin
 ganttproject-builder/dist-win
 ganttproject-builder/dist-bin
 ganttproject-builder/runtime
+**/*.css.map

--- a/ganttproject/src/main/java/biz/ganttproject/app/Barriers.kt
+++ b/ganttproject/src/main/java/biz/ganttproject/app/Barriers.kt
@@ -83,7 +83,13 @@ class TwoPhaseBarrierImpl<T>(private val name: String) : Barrier<T>, BarrierEntr
   val isActive: Boolean get() = value != null
 
   fun activate(exitValue: T) {
+    if (value != null) {
+      error("You can't activate the barrier twice. There is an existing value: $value")
+    }
     value = exitValue
+    if (counter.get() == 0) {
+      callExits()
+    }
   }
 
   override fun await(code: BarrierExit<T>) {

--- a/ganttproject/src/main/java/biz/ganttproject/app/Barriers.kt
+++ b/ganttproject/src/main/java/biz/ganttproject/app/Barriers.kt
@@ -71,24 +71,25 @@ class SimpleBarrier<T> : Barrier<T> {
  * Once all registered entrance activities reach the barrier, it opens it's exit and
  * starts the exit activities.
  */
-class TwoPhaseBarrierImpl<T>(private val name: String, private val value: T) : Barrier<T>, BarrierEntrance {
+class TwoPhaseBarrierImpl<T>(private val name: String) : Barrier<T>, BarrierEntrance {
+  constructor(name: String, value: T): this(name) {
+    activate(value)
+  }
+  private var value: T? = null
   private val counter = AtomicInteger(0)
   private val exits = mutableListOf<BarrierExit<T>>()
   private val activities = mutableMapOf<String, OnBarrierReached>()
 
-  var isActive: Boolean = false
-  set(value) {
-    val wasActive = field
-    field = value
-    // If there are exits, but no activities, we call exit immediately
-    if (value && !wasActive && counter.get() == 0) {
-      exits.forEach { it(this.value) }
-    }
+  val isActive: Boolean get() = value != null
+
+  fun activate(exitValue: T) {
+    value = exitValue
   }
 
   override fun await(code: BarrierExit<T>) {
-    assert(!isActive) {
-      "You need to register barrier exits before it is activated"
+    if (isActive && counter.get() == 0) {
+      code(value!!)
+      return
     }
     exits.add(code)
   }
@@ -114,9 +115,14 @@ class TwoPhaseBarrierImpl<T>(private val name: String, private val value: T) : B
 
   private fun tick() {
     if (counter.decrementAndGet() == 0) {
-      BARRIER_LOGGER.debug("Barrier $name: reached.")
-      exits.forEach { it(value) }
+      callExits()
     }
+  }
+
+  private fun callExits() {
+    BARRIER_LOGGER.debug("Barrier $name: reached.")
+    val exitValue = value ?: error("No value was set for the barrier $name")
+    exits.forEach { it(exitValue) }
   }
 }
 

--- a/ganttproject/src/main/java/biz/ganttproject/app/Dialog.kt
+++ b/ganttproject/src/main/java/biz/ganttproject/app/Dialog.kt
@@ -317,7 +317,7 @@ class DialogControllerSwing : DialogController {
 
   override fun toggleProgress(shown: Boolean): () -> Unit {
     val countDown = CountDownLatch(2)
-    GlobalScope.launch(Dispatchers.JavaFx) {
+    FXThread.runLater {
       val transition = createOverlayPane(this@DialogControllerSwing.content, this@DialogControllerSwing.contentStack) {pane ->
         pane.center = Spinner().let {
           it.state = Spinner.State.WAITING
@@ -400,31 +400,8 @@ class DialogControllerSwing : DialogController {
   }
 
   override fun removeButtonBar() {
-//    this.buttons.clear()
-//    this.buttonNodes.clear()
     this.buttonBarDisabled = true
-    //this.buttonBar = null
   }
-
-//  private fun updateButtons(buttonBar: ButtonBar) {
-//    buttonBar.buttons.clear()
-//    // show details button if expandable content is present
-//    var hasDefault = false
-//    for (cmd in buttons) {
-//      val button = buttonNodes.computeIfAbsent(cmd, ::createButton)
-//      // keep only first default button
-//      val buttonType = cmd.buttonData
-//      button.isDefaultButton = !hasDefault && buttonType != null && buttonType.isDefaultButton
-//      button.isCancelButton = buttonType != null && buttonType.isCancelButton
-//      hasDefault = hasDefault || buttonType != null && buttonType.isDefaultButton
-//      buttonBar.buttons.add(button)
-//
-//      button.addEventHandler(ActionEvent.ACTION) { ae: ActionEvent ->
-//        if (ae.isConsumed) return@addEventHandler
-//        hide()
-//      }
-//    }
-//  }
 
   private fun createButton(buttonType: ButtonType): Button {
     val button = Button(buttonType.text)
@@ -521,15 +498,9 @@ class DialogControllerFx(private val dialogPane: DialogPaneExt, private val dial
         bb.height = 5.0
         bb.iterations = 2
       }
-//      createOverlayPane(this.content, this.stackPane) {pane ->
-//        pane.styleClass.add("overlay")
-//        pane.center = Label("")
-//        pane.opacity = 0.5
-//      }
     }
     return {
       Platform.runLater {
-//        this.stackPane.children.removeIf { it.styleClass.contains("overlay") }
         this.content.effect = null
       }
     }

--- a/ganttproject/src/main/java/biz/ganttproject/app/Dialog.kt
+++ b/ganttproject/src/main/java/biz/ganttproject/app/Dialog.kt
@@ -515,14 +515,23 @@ class DialogControllerFx(private val dialogPane: DialogPaneExt, private val dial
   }
 
   override fun toggleProgress(shown: Boolean): () -> Unit {
-    Platform.runLater {
-      createOverlayPane(this.content, this.stackPane) {pane ->
-        pane.center = Label("")
-        pane.opacity = 0.5
+    FXThread.runLater {
+      this.content.effect = BoxBlur().also { bb ->
+        bb.width = 5.0
+        bb.height = 5.0
+        bb.iterations = 2
       }
+//      createOverlayPane(this.content, this.stackPane) {pane ->
+//        pane.styleClass.add("overlay")
+//        pane.center = Label("")
+//        pane.opacity = 0.5
+//      }
     }
     return {
-      this.stackPane.children.removeIf { it.styleClass.contains("overlay") }
+      Platform.runLater {
+//        this.stackPane.children.removeIf { it.styleClass.contains("overlay") }
+        this.content.effect = null
+      }
     }
   }
 

--- a/ganttproject/src/main/java/biz/ganttproject/core/table/BaseTreeTableComponent.kt
+++ b/ganttproject/src/main/java/biz/ganttproject/core/table/BaseTreeTableComponent.kt
@@ -30,8 +30,6 @@ import biz.ganttproject.lib.fx.GPTreeTableView
 import biz.ganttproject.lib.fx.depthFirstWalk
 import javafx.beans.property.ReadOnlyDoubleProperty
 import javafx.beans.property.SimpleObjectProperty
-import javafx.collections.FXCollections
-import javafx.collections.ObservableList
 import javafx.event.EventHandler
 import javafx.scene.control.TreeItem
 import javafx.scene.input.KeyCode
@@ -98,7 +96,7 @@ abstract class BaseTreeTableComponent<NodeType, BuiltinColumnType: BuiltinColumn
   }
 
   protected fun initProjectEventHandlers() {
-    projectOpenActivityFactory.addListener { sm ->
+    projectOpenActivityFactory.addBuilder { sm ->
       areChangesIgnored = true
       val tablesReadyStateEntrance = sm.stateTablesReady.register("Reload ${this.javaClass.simpleName}")
       sm.stateMainModelReady.await {

--- a/ganttproject/src/main/java/biz/ganttproject/core/table/BaseTreeTableComponent.kt
+++ b/ganttproject/src/main/java/biz/ganttproject/core/table/BaseTreeTableComponent.kt
@@ -111,6 +111,12 @@ abstract class BaseTreeTableComponent<NodeType, BuiltinColumnType: BuiltinColumn
           treeTable.requestFocus()
         }
       }
+      sm.stateCancelled.await {
+        areChangesIgnored = false
+        FXThread.runLater {
+          treeTable.requestFocus()
+        }
+      }
       sm.stateFailed.await {
         areChangesIgnored = false
       }

--- a/ganttproject/src/main/java/biz/ganttproject/ganttview/TaskTable.kt
+++ b/ganttproject/src/main/java/biz/ganttproject/ganttview/TaskTable.kt
@@ -87,7 +87,7 @@ class TaskTable(
   private val taskActions: TaskActions,
   private val undoManager: GPUndoManager,
   val filterManager: TaskFilterManager,
-  initializationPromise: TwoPhaseBarrierImpl<*>,
+  private val initializationCompleted: OnBarrierReached,
   private val newTaskActor: NewTaskActor<Task>,
   projectOpenActivityFactory: ProjectOpenActivityFactory
 ):
@@ -132,7 +132,6 @@ class TaskTable(
   }
   private val placeholderEmpty by lazy { Pane() }
 
-  private val initializationCompleted = initializationPromise.register("Task table initialization")
   override val selectionKeeper = SelectionKeeper(logger = LOGGER, treeTable = this.treeTable, node2treeItem = { task ->
     taskManager.getTask(task.taskID)?.let {
       task2treeItem[it]

--- a/ganttproject/src/main/java/biz/ganttproject/storage/Document.kt
+++ b/ganttproject/src/main/java/biz/ganttproject/storage/Document.kt
@@ -388,3 +388,4 @@ fun DocumentManager.loadRecentDocs(
 }
 
 private val LOG = GPLogger.create("Document")
+val DOCUMENT_LOGGER = LOG

--- a/ganttproject/src/main/java/biz/ganttproject/storage/StorageDialogBuilder.kt
+++ b/ganttproject/src/main/java/biz/ganttproject/storage/StorageDialogBuilder.kt
@@ -77,7 +77,7 @@ class StorageDialogBuilder(
         killProgress()
         authFlow(onAuth)
       }
-      projectUi.openProject(documentManager.getProxyDocument(document), myProject, null, proxyAuthFlow).let { sm ->
+      projectUi.openProject(documentManager.getProxyDocument(document), myProject, proxyAuthFlow).let { sm ->
         sm.stateCompleted.await {
           myDialogUi.close()
         }

--- a/ganttproject/src/main/java/biz/ganttproject/storage/StorageDialogBuilder.kt
+++ b/ganttproject/src/main/java/biz/ganttproject/storage/StorageDialogBuilder.kt
@@ -91,6 +91,9 @@ class StorageDialogBuilder(
         sm.stateCompleted.await {
           myDialogUi.close()
         }
+        sm.stateCancelled.await {
+          myDialogUi.close()
+        }
         sm.stateFailed.await { stateFailed ->
           killProgress()
           myDialogUi.error(stateFailed.errorTitle, stateFailed.errorDescription, stateFailed.throwable)

--- a/ganttproject/src/main/java/biz/ganttproject/storage/StorageDialogBuilder.kt
+++ b/ganttproject/src/main/java/biz/ganttproject/storage/StorageDialogBuilder.kt
@@ -32,6 +32,9 @@ import javafx.scene.layout.*
 import javafx.stage.Screen
 import net.sourceforge.ganttproject.GPLogger
 import net.sourceforge.ganttproject.IGanttProject
+import net.sourceforge.ganttproject.ProjectOpenActivityAuthRequired
+import net.sourceforge.ganttproject.ProjectOpenActivityFactory
+import net.sourceforge.ganttproject.ProjectOpenActivityStarted
 import net.sourceforge.ganttproject.document.Document
 import net.sourceforge.ganttproject.document.DocumentManager
 import net.sourceforge.ganttproject.document.ReadOnlyProxyDocument
@@ -77,7 +80,14 @@ class StorageDialogBuilder(
         killProgress()
         authFlow(onAuth)
       }
-      projectUi.openProject(documentManager.getProxyDocument(document), myProject, proxyAuthFlow).let { sm ->
+      ProjectOpenActivityFactory.createStateMachine(myProject).let { sm ->
+        sm.stateAuthRequired.await { state ->
+          proxyAuthFlow {
+            if (sm.state is ProjectOpenActivityAuthRequired) {
+              sm.state = ProjectOpenActivityStarted(state.document)
+            }
+          }
+        }
         sm.stateCompleted.await {
           myDialogUi.close()
         }
@@ -86,6 +96,8 @@ class StorageDialogBuilder(
           myDialogUi.error(stateFailed.errorTitle, stateFailed.errorDescription, stateFailed.throwable)
           LOG.error("Failed to open document {}", document.uri, exception = stateFailed.throwable)
         }
+
+        sm.start(documentManager.getProxyDocument(document))
       }
     }
     // This will be called when user saves a project.

--- a/ganttproject/src/main/java/biz/ganttproject/storage/cloud/ColloboqueClient.kt
+++ b/ganttproject/src/main/java/biz/ganttproject/storage/cloud/ColloboqueClient.kt
@@ -18,18 +18,59 @@ along with GanttProject.  If not, see <http://www.gnu.org/licenses/>.
 */
 package biz.ganttproject.storage.cloud
 
+import biz.ganttproject.core.calendar.ImportCalendarOption
+import javafx.application.Platform
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.selects.select
 import net.sourceforge.ganttproject.GPLogger
+import net.sourceforge.ganttproject.IGanttProject
+import net.sourceforge.ganttproject.gui.UIFacade
+import net.sourceforge.ganttproject.importer.BufferProject
+import net.sourceforge.ganttproject.importer.asImportBufferProjectApi
+import net.sourceforge.ganttproject.importer.importBufferProject
+import net.sourceforge.ganttproject.resource.HumanResourceMerger
+import net.sourceforge.ganttproject.resource.MergeResourcesEnum
 import net.sourceforge.ganttproject.storage.*
+import net.sourceforge.ganttproject.task.export
+import net.sourceforge.ganttproject.task.importFromDatabase
 import net.sourceforge.ganttproject.undo.GPUndoListener
 import net.sourceforge.ganttproject.undo.GPUndoManager
 import java.util.*
 import java.util.concurrent.Executors
 import javax.swing.event.UndoableEditEvent
+
+fun installColloboque(it: GPCloudDocument, project: IGanttProject, undoManager: GPUndoManager, uiFacade: UIFacade) {
+  if (!isColloboqueOn()) return
+  it.colloboqueClient = ColloboqueClient(project.projectDatabase, undoManager)
+  project.projectDatabase.addExternalUpdatesListener {
+    Platform.runLater {
+      val emptyTaskManager = project.taskManager.emptyClone()
+      emptyTaskManager.importFromDatabase(project.projectDatabase.readAllTasks(), project.taskManager.taskHierarchy.export())
+      val bufferProject = BufferProject(
+        emptyTaskManager,
+        project.projectDatabase,
+        project.roleManager,
+        project.activeCalendar,
+        uiFacade
+      )
+      val mergeOption = HumanResourceMerger.MergeResourcesOption()
+      val importCalendarOption = ImportCalendarOption()
+      mergeOption.setSelectedValue(MergeResourcesEnum.BY_ID)
+      importCalendarOption.loadPersistentValue(ImportCalendarOption.Values.REPLACE.name)
+      importBufferProject(
+        project,
+        bufferProject,
+        uiFacade.asImportBufferProjectApi(),
+        mergeOption,
+        importCalendarOption,
+        closeCurrentProject = true
+      )
+    }
+  }
+}
 
 class ColloboqueClient(private val projectDatabase: ProjectDatabase, undoManager: GPUndoManager) {
   private val myBaseTxnCommitInfo = TxnCommitInfo(0)
@@ -174,6 +215,10 @@ private class TxnCommitInfo(var baseTxnId: BaseTxnId) {
     UUID.randomUUID().toString().replace("-", "").also {
       trackingCode = it
     }
+}
+
+private fun isColloboqueOn() = System.getProperty("enable_colloboque", System.getenv("ENABLE_COLLOBOQUE") ?: "false").lowercase().let {
+  it.toBooleanStrictOrNull() ?: false
 }
 
 private val LOG = GPLogger.create("Cloud.RealTimeSync")

--- a/ganttproject/src/main/java/biz/ganttproject/storage/cloud/DocPropertiesUi.kt
+++ b/ganttproject/src/main/java/biz/ganttproject/storage/cloud/DocPropertiesUi.kt
@@ -410,10 +410,6 @@ class DocPropertiesUi(val errorUi: ErrorUi, val busyUi: BusyUi) {
       }
     }
   }
-
-  fun showDialog(document: GPCloudDocument, fetchConsumer: (FetchResult) -> Unit) {
-    dialog { dialogController -> addContent( dialogController, document, fetchConsumer) }
-  }
 }
 
 class ProjectPropertiesPageProvider : OptionPageProviderBase("project.cloud"), FxUiComponent {
@@ -444,15 +440,17 @@ class ProjectPropertiesPageProvider : OptionPageProviderBase("project.cloud"), F
     val onlineDocument = this.project.document.asOnlineDocument() ?: return buildNotOnlineDocumentNode()
     return if (onlineDocument is GPCloudDocument) {
       val group = BorderPane()
-      val dialogBuildApi = DialogControllerPane(group)
-      DocPropertiesUi(errorUi = {}, busyUi = {}).addContent(dialogBuildApi, onlineDocument, this::onOnlineDocFetch)
+      val dlg = DialogControllerPane(group)
+      DocPropertiesUi(errorUi = {}, busyUi = {}).addContent(dlg, onlineDocument, { _ ->
+        onOnlineDocFetch(dlg)
+      })
       group
     } else {
       buildNotOnlineDocumentNode()
     }
   }
 
-  private fun onOnlineDocFetch(fetchResult: FetchResult) {
+  private fun onOnlineDocFetch(dlg: DialogController) {
     val document = this.project.document
     ProjectOpenActivityFactory.createStateMachine(project).let { sm ->
       sm.stateAuthRequired.await {
@@ -461,6 +459,10 @@ class ProjectPropertiesPageProvider : OptionPageProviderBase("project.cloud"), F
             sm.state = ProjectOpenActivityStarted(document)
           }
         }
+      }
+      sm.stateFailed.await {
+        DOCUMENT_LOGGER.error("${it.errorTitle}: ${it.errorDescription}", exception = it.throwable)
+        dlg.showAlert(it.errorTitle, createAlertBody(it.errorDescription))
       }
       sm.start(document)
     }

--- a/ganttproject/src/main/java/biz/ganttproject/storage/cloud/DocPropertiesUi.kt
+++ b/ganttproject/src/main/java/biz/ganttproject/storage/cloud/DocPropertiesUi.kt
@@ -43,6 +43,7 @@ import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.javafx.JavaFx
 import net.sourceforge.ganttproject.GPLogger
+import net.sourceforge.ganttproject.ProjectOpenStateMachine
 import net.sourceforge.ganttproject.document.Document
 import net.sourceforge.ganttproject.gui.ProjectOpenStrategy
 import net.sourceforge.ganttproject.gui.options.OptionPageProviderBase
@@ -55,6 +56,7 @@ import java.util.*
 import java.util.concurrent.Executors
 import javax.swing.JPanel
 import javax.swing.SwingUtilities
+import kotlin.coroutines.EmptyCoroutineContext
 
 typealias OnLockDone = (JsonNode?) -> Unit
 typealias BusyUi = (Boolean) -> Unit
@@ -454,7 +456,8 @@ class ProjectPropertiesPageProvider : OptionPageProviderBase("project.cloud"), F
 
   private fun onOnlineDocFetch(fetchResult: FetchResult) {
     val document = this.project.document
-    ProjectOpenStrategy(project, uiFacade) { onAuth -> onAuth() }.use { strategy ->
+    val stateMachine = ProjectOpenStateMachine(project, CoroutineScope(EmptyCoroutineContext))
+    ProjectOpenStrategy(project, uiFacade, signin = { onAuth -> onAuth() }, stateMachine).use { strategy ->
       val docChannel = Channel<Document>()
       CoroutineScope(Executors.newSingleThreadExecutor().asCoroutineDispatcher()).launch {
         try {

--- a/ganttproject/src/main/java/biz/ganttproject/storage/cloud/DocPropertiesUi.kt
+++ b/ganttproject/src/main/java/biz/ganttproject/storage/cloud/DocPropertiesUi.kt
@@ -22,7 +22,6 @@ import biz.ganttproject.FxUiComponent
 import biz.ganttproject.app.*
 import biz.ganttproject.core.option.GPOptionGroup
 import biz.ganttproject.lib.fx.VBoxBuilder
-import biz.ganttproject.app.DialogControllerPane
 import biz.ganttproject.storage.*
 import com.fasterxml.jackson.databind.JsonNode
 import de.jensd.fx.glyphs.fontawesome.FontAwesomeIcon
@@ -39,24 +38,23 @@ import javafx.scene.control.*
 import javafx.scene.layout.BorderPane
 import javafx.scene.layout.Pane
 import javafx.scene.layout.Priority
-import kotlinx.coroutines.*
-import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.javafx.JavaFx
+import kotlinx.coroutines.launch
 import net.sourceforge.ganttproject.GPLogger
-import net.sourceforge.ganttproject.ProjectOpenStateMachine
-import net.sourceforge.ganttproject.document.Document
-import net.sourceforge.ganttproject.gui.ProjectOpenStrategy
+import net.sourceforge.ganttproject.ProjectOpenActivityAuthRequired
+import net.sourceforge.ganttproject.ProjectOpenActivityFactory
+import net.sourceforge.ganttproject.ProjectOpenActivityStarted
 import net.sourceforge.ganttproject.gui.options.OptionPageProviderBase
+import net.sourceforge.ganttproject.gui.projectopen.signinDialog
 import net.sourceforge.ganttproject.language.GanttLanguage
 import java.awt.BorderLayout
 import java.awt.Component
 import java.io.IOException
 import java.time.Duration
 import java.util.*
-import java.util.concurrent.Executors
 import javax.swing.JPanel
-import javax.swing.SwingUtilities
-import kotlin.coroutines.EmptyCoroutineContext
 
 typealias OnLockDone = (JsonNode?) -> Unit
 typealias BusyUi = (Boolean) -> Unit
@@ -456,25 +454,15 @@ class ProjectPropertiesPageProvider : OptionPageProviderBase("project.cloud"), F
 
   private fun onOnlineDocFetch(fetchResult: FetchResult) {
     val document = this.project.document
-    val stateMachine = ProjectOpenStateMachine(project, CoroutineScope(EmptyCoroutineContext))
-    ProjectOpenStrategy(project, uiFacade, signin = { onAuth -> onAuth() }, stateMachine).use { strategy ->
-      val docChannel = Channel<Document>()
-      CoroutineScope(Executors.newSingleThreadExecutor().asCoroutineDispatcher()).launch {
-        try {
-          docChannel.receive().also {
-            // If document is obtained, we need to run further steps.
-            // Because of historical reasons they run in Swing thread (they may modify the state of Swing components)
-            SwingUtilities.invokeLater {
-              uiFacade.undoManager.die()
-              project.close()
-              strategy.openFileAsIs(it)
-            }
+    ProjectOpenActivityFactory.createStateMachine(project).let { sm ->
+      sm.stateAuthRequired.await {
+        signinDialog {
+          if (sm.state is ProjectOpenActivityAuthRequired) {
+            sm.state = ProjectOpenActivityStarted(document)
           }
-        } catch (ex: Exception) {
-          GPLogger.log(ex)
         }
       }
-      strategy.open(document, docChannel)
+      sm.start(document)
     }
   }
 

--- a/ganttproject/src/main/java/biz/ganttproject/storage/cloud/GPCloudDocument.kt
+++ b/ganttproject/src/main/java/biz/ganttproject/storage/cloud/GPCloudDocument.kt
@@ -132,17 +132,17 @@ class GPCloudDocument(val teamRefid: String?,
       }
     }
     get() {
-      return (field ?: {
-        val fp = this.projectIdFingerprint
-        val fileOptions = GPCloudOptions.cloudFiles.getFileOptions(fp)
-        val onlineOnly = fileOptions.onlineOnly.toBoolean()
-        val offlineMirrorPath = fileOptions.offlineMirror
-        if (!onlineOnly && offlineMirrorPath != null && Files.exists(Paths.get(offlineMirrorPath))) {
-          this.offlineDocumentFactory(offlineMirrorPath)
+      return (field ?: run {
+        val fp1 = projectIdFingerprint
+        val fileOptions1 = GPCloudOptions.cloudFiles.getFileOptions(fp1)
+        val onlineOnly1 = fileOptions1.onlineOnly.toBoolean()
+        val offlineMirrorPath1 = fileOptions1.offlineMirror
+        if (!onlineOnly1 && offlineMirrorPath1 != null && Files.exists(Paths.get(offlineMirrorPath1))) {
+          offlineDocumentFactory(offlineMirrorPath1)
         } else {
           null
         }
-      }()).also {
+      }).also {
         field = it
       }
     }
@@ -587,9 +587,13 @@ class GPCloudDocument(val teamRefid: String?,
   }
 }
 
-fun GPCloudDocument.onboard(documentManager: DocumentManager, webSocket: WebSocketClient) {
+fun GPCloudDocument.installOfflineMirror(documentManager: DocumentManager) {
   this.offlineDocumentFactory = { path -> documentManager.newDocument(path) }
   this.proxyDocumentFactory = documentManager::getProxyDocument
+}
+
+fun GPCloudDocument.onboard(documentManager: DocumentManager, webSocket: WebSocketClient) {
+  installOfflineMirror(documentManager)
   webSocket.register(this)
   this.projectRefid?.let { webSocket.sendProjectRefId(it) }
 
@@ -600,4 +604,3 @@ fun GPCloudDocument.onboard(documentManager: DocumentManager, webSocket: WebSock
 
 private val ourExecutor = Executors.newSingleThreadExecutor()
 private val LOG = GPLogger.create("Cloud.Document")
-

--- a/ganttproject/src/main/java/biz/ganttproject/storage/cloud/GPCloudHttpImpl.kt
+++ b/ganttproject/src/main/java/biz/ganttproject/storage/cloud/GPCloudHttpImpl.kt
@@ -22,6 +22,7 @@ import biz.ganttproject.app.RootLocalizer
 import biz.ganttproject.storage.DocumentUri
 import biz.ganttproject.storage.ForbiddenException
 import biz.ganttproject.storage.Path
+import biz.ganttproject.storage.asOnlineDocument
 import biz.ganttproject.storage.cloud.http.JsonTask
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
@@ -279,7 +280,9 @@ class WebSocketClient {
   init {
     ProjectOpenActivityFactory.addBuilder { sm ->
       sm.stateCompleted.await {
-        println("!!!!!!!!!")
+        it.document.asOnlineDocument()?.let {
+          webSocket.start()
+        }
       }
     }
   }

--- a/ganttproject/src/main/java/biz/ganttproject/storage/cloud/GPCloudHttpImpl.kt
+++ b/ganttproject/src/main/java/biz/ganttproject/storage/cloud/GPCloudHttpImpl.kt
@@ -281,7 +281,7 @@ class WebSocketClient {
     ProjectOpenActivityFactory.addBuilder { sm ->
       sm.stateCompleted.await {
         it.document.asOnlineDocument()?.let {
-          webSocket.start()
+          start()
         }
       }
     }

--- a/ganttproject/src/main/java/biz/ganttproject/storage/cloud/GPCloudHttpImpl.kt
+++ b/ganttproject/src/main/java/biz/ganttproject/storage/cloud/GPCloudHttpImpl.kt
@@ -38,6 +38,7 @@ import kotlinx.coroutines.*
 import kotlinx.serialization.json.Json
 import net.sourceforge.ganttproject.GPLogger
 import net.sourceforge.ganttproject.GPVersion
+import net.sourceforge.ganttproject.ProjectOpenActivityFactory
 import net.sourceforge.ganttproject.storage.*
 import okhttp3.*
 import org.apache.commons.codec.binary.Base64InputStream
@@ -275,6 +276,13 @@ class WebSocketClient {
   private val baseTxnIdListeners = mutableListOf<(String) -> Unit>()
   private var listeningDocument: GPCloudDocument? = null
 
+  init {
+    ProjectOpenActivityFactory.addBuilder { sm ->
+      sm.stateCompleted.await {
+        println("!!!!!!!!!")
+      }
+    }
+  }
   private fun getWebSocketUrl() = GPCLOUD_WEBSOCKET_URL
 
   private fun getConnectionSpecs() = if (isColloboqueLocalTest()) {

--- a/ganttproject/src/main/java/biz/ganttproject/storage/cloud/GPCloudStatusBar.kt
+++ b/ganttproject/src/main/java/biz/ganttproject/storage/cloud/GPCloudStatusBar.kt
@@ -277,6 +277,7 @@ class GPCloudStatusBar(
           text = STATUS_BAR_LOCALIZER.formatText("mode.onlineOnly")
           graphic = FontAwesomeIconView(FontAwesomeIcon.CLOUD)
           tooltip = Tooltip(STATUS_BAR_LOCALIZER.formatText("mode.onlineOnly.tooltip"))
+          // TODO(dbarashev): restore offline-only mode indication
           //Decorator.removeAllDecorations(this)
           isDisable = false
         }

--- a/ganttproject/src/main/java/biz/ganttproject/storage/cloud/GPCloudStatusBar.kt
+++ b/ganttproject/src/main/java/biz/ganttproject/storage/cloud/GPCloudStatusBar.kt
@@ -18,11 +18,7 @@ along with GanttProject.  If not, see <http://www.gnu.org/licenses/>.
 */
 package biz.ganttproject.storage.cloud
 
-import biz.ganttproject.app.OptionElementData
-import biz.ganttproject.app.OptionPaneBuilder
-import biz.ganttproject.app.RootLocalizer
-import biz.ganttproject.app.createAlertBody
-import biz.ganttproject.app.dialog
+import biz.ganttproject.app.*
 import biz.ganttproject.core.time.GanttCalendar
 import biz.ganttproject.lib.fx.createToggleSwitch
 import biz.ganttproject.storage.*
@@ -36,7 +32,6 @@ import javafx.application.Platform
 import javafx.beans.value.ChangeListener
 import javafx.beans.value.ObservableObjectValue
 import javafx.event.ActionEvent
-import javafx.geometry.Pos
 import javafx.scene.Node
 import javafx.scene.control.Button
 import javafx.scene.control.Label
@@ -46,7 +41,6 @@ import javafx.scene.layout.HBox
 import javafx.scene.shape.Circle
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.javafx.JavaFx
 import kotlinx.coroutines.launch
 import net.sourceforge.ganttproject.GPLogger
 import net.sourceforge.ganttproject.IGanttProject
@@ -55,9 +49,8 @@ import net.sourceforge.ganttproject.document.Document
 import net.sourceforge.ganttproject.document.ProxyDocument
 import net.sourceforge.ganttproject.gui.ProjectUIFacade
 import net.sourceforge.ganttproject.gui.UIFacade
+import net.sourceforge.ganttproject.gui.projectopen.showProjectOpenErrorDialog
 import net.sourceforge.ganttproject.language.GanttLanguage
-import org.controlsfx.control.decoration.Decorator
-import org.controlsfx.control.decoration.GraphicDecoration
 import java.time.Duration
 import java.time.temporal.ChronoUnit
 import java.util.*
@@ -194,8 +187,7 @@ class GPCloudStatusBar(
 
   // This is called whenever open document changes and handles different cases.
   private fun onDocumentChange(oldDocument: Document?, newDocument: Document?) {
-    GlobalScope.launch(Dispatchers.JavaFx) {
-
+    FXThread.runLater {
       // First we un-proxy old and new documents.
       val newDoc = if (newDocument is ProxyDocument) {
         newDocument.realDocument
@@ -250,7 +242,7 @@ class GPCloudStatusBar(
   }
 
   private fun onLockStatusChange(newStatus: LockStatus) {
-    GlobalScope.launch(Dispatchers.JavaFx) {
+    FXThread.runLater {
       updateLockStatus(newStatus)
     }
   }
@@ -273,7 +265,7 @@ class GPCloudStatusBar(
   }
 
   private fun onOnlineModeChange(newValue: OnlineDocumentMode) {
-    GlobalScope.launch(Dispatchers.JavaFx) {
+    FXThread.runLater {
       updateOnlineMode(newValue)
     }
   }
@@ -343,7 +335,9 @@ class GPCloudStatusBar(
           GlobalScope.launch(Dispatchers.IO) {
             doc.fetch().also {
               it.update()
-              projectUIFacade.openProject(newDocument, this@GPCloudStatusBar.project, null)
+              projectUIFacade.openProject(newDocument, this@GPCloudStatusBar.project, null).apply {
+                stateFailed.await { error -> error.showProjectOpenErrorDialog(newDocument, uiFacade.notificationManager) }
+              }
             }
           }
         }
@@ -407,12 +401,12 @@ private class ReconnectStatus(private val label: Label) {
 
   private fun startCountdown(nextTry: Duration) {
     LOG.debug("The next ping is in {}. Starting countdown", nextTry)
-    GlobalScope.launch(Dispatchers.JavaFx) { this@ReconnectStatus.label.isVisible = true }
+    FXThread.runLater { this@ReconnectStatus.label.isVisible = true }
     val remainingSeconds = AtomicLong(nextTry.seconds)
     this.statusUpdateFuture = statusUpdateExecutor.scheduleWithFixedDelay({
       LOG.debug("... {} seconds", remainingSeconds.get())
       if (remainingSeconds.get() > 0) {
-        GlobalScope.launch(Dispatchers.JavaFx) { reconnectText.update(remainingSeconds.getAndDecrement().toString()) }
+        FXThread.runLater { reconnectText.update(remainingSeconds.getAndDecrement().toString()) }
       } else {
         throw RuntimeException("Cancelling this status update")
       }

--- a/ganttproject/src/main/java/biz/ganttproject/storage/cloud/GPCloudStatusBar.kt
+++ b/ganttproject/src/main/java/biz/ganttproject/storage/cloud/GPCloudStatusBar.kt
@@ -276,7 +276,7 @@ class GPCloudStatusBar(
           text = STATUS_BAR_LOCALIZER.formatText("mode.onlineOnly")
           graphic = FontAwesomeIconView(FontAwesomeIcon.CLOUD)
           tooltip = Tooltip(STATUS_BAR_LOCALIZER.formatText("mode.onlineOnly.tooltip"))
-          Decorator.removeAllDecorations(this)
+          //Decorator.removeAllDecorations(this)
           isDisable = false
         }
         this.btnLock.isDisable = false
@@ -286,7 +286,7 @@ class GPCloudStatusBar(
           text = STATUS_BAR_LOCALIZER.formatText("mode.mirror")
           graphic = FontAwesomeIconView(FontAwesomeIcon.CLOUD_DOWNLOAD)
           tooltip = Tooltip(STATUS_BAR_LOCALIZER.formatText("mode.mirror.tooltip"))
-          Decorator.removeAllDecorations(this)
+          //Decorator.removeAllDecorations(this)
           isDisable = false
         }
         this.btnLock.isDisable = false
@@ -296,7 +296,7 @@ class GPCloudStatusBar(
           text = STATUS_BAR_LOCALIZER.formatText("mode.offline")
           graphic = FontAwesomeIconView(FontAwesomeIcon.CLOUD_DOWNLOAD)
           tooltip = Tooltip(STATUS_BAR_LOCALIZER.formatText("mode.offline.tooltip"))
-          Decorator.addDecoration(this, GraphicDecoration(createWarningDecoration(), Pos.BOTTOM_LEFT, 6.0, -4.0))
+          //Decorator.addDecoration(this, GraphicDecoration(createWarningDecoration(), Pos.BOTTOM_LEFT, 6.0, -4.0))
           isDisable = true
         }
 

--- a/ganttproject/src/main/java/biz/ganttproject/storage/cloud/GPCloudStatusBar.kt
+++ b/ganttproject/src/main/java/biz/ganttproject/storage/cloud/GPCloudStatusBar.kt
@@ -21,6 +21,7 @@ package biz.ganttproject.storage.cloud
 import biz.ganttproject.app.OptionElementData
 import biz.ganttproject.app.OptionPaneBuilder
 import biz.ganttproject.app.RootLocalizer
+import biz.ganttproject.app.createAlertBody
 import biz.ganttproject.app.dialog
 import biz.ganttproject.core.time.GanttCalendar
 import biz.ganttproject.lib.fx.createToggleSwitch
@@ -176,8 +177,16 @@ class GPCloudStatusBar(
     this.observableDocument.get().apply {
       val onlineDocument = this.asOnlineDocument()
       if (onlineDocument is GPCloudDocument) {
-        DocPropertiesUi(errorUi = {}, busyUi = {}).showDialog(onlineDocument) {
-          projectUIFacade.openProject(this, this@GPCloudStatusBar.project, null)
+        val docPropertiesUi = DocPropertiesUi(errorUi = {}, busyUi = {})
+        dialog { dlg ->
+          docPropertiesUi.addContent( dlg, onlineDocument) { unusedFetchResult ->
+            // If the fetch result is okay, its contents will be returned from the online document.
+            val sm = projectUIFacade.openProject(this, this@GPCloudStatusBar.project, null)
+            sm.stateFailed.await {
+              DOCUMENT_LOGGER.error("${it.errorTitle}: ${it.errorDescription}", exception = it.throwable)
+              dlg.showAlert(it.errorTitle, createAlertBody(it.errorDescription))
+            }
+          }
         }
       }
     }

--- a/ganttproject/src/main/java/net/sourceforge/ganttproject/DesktopIntegration.java
+++ b/ganttproject/src/main/java/net/sourceforge/ganttproject/DesktopIntegration.java
@@ -55,23 +55,21 @@ public class DesktopIntegration {
 
         @Override
         public void openFile(final File file) {
-          javax.swing.SwingUtilities.invokeLater(() -> {
-            var barrier = projectUiFacade.ensureProjectSaved(project);
-            barrier.await(result -> {
-              if (result) {
-                Document myDocument = project.getDocumentManager().getDocument(file.getAbsolutePath());
-                try {
-                  var sm = projectUiFacade.openProject(myDocument, project, null);
-                  sm.getStateFailed().await(error -> {
-                    ErrorHandlingKt.showProjectOpenErrorDialog(error, myDocument, uiFacade.getNotificationManager());
-                    return Unit.INSTANCE;
-                  });
-                } catch (Document.DocumentException | IOException ex) {
-                  uiFacade.showErrorDialog(ex);
-                }
+          var barrier = projectUiFacade.ensureProjectSaved(project);
+          barrier.await(result -> {
+            if (result) {
+              Document myDocument = project.getDocumentManager().getDocument(file.getAbsolutePath());
+              try {
+                var sm = projectUiFacade.openProject(myDocument, project, null);
+                sm.getStateFailed().await(error -> {
+                  ErrorHandlingKt.showProjectOpenErrorDialog(error, myDocument, uiFacade.getNotificationManager());
+                  return Unit.INSTANCE;
+                });
+              } catch (Document.DocumentException | IOException ex) {
+                uiFacade.showErrorDialog(ex);
               }
-              return Unit.INSTANCE;
-            });
+            }
+            return Unit.INSTANCE;
           });
         }
       });

--- a/ganttproject/src/main/java/net/sourceforge/ganttproject/DesktopIntegration.java
+++ b/ganttproject/src/main/java/net/sourceforge/ganttproject/DesktopIntegration.java
@@ -60,7 +60,7 @@ public class DesktopIntegration {
               if (result) {
                 Document myDocument = project.getDocumentManager().getDocument(file.getAbsolutePath());
                 try {
-                  projectUiFacade.openProject(myDocument, project, null, null);
+                  projectUiFacade.openProject(myDocument, project, null);
                 } catch (Document.DocumentException | IOException ex) {
                   uiFacade.showErrorDialog(ex);
                 }

--- a/ganttproject/src/main/java/net/sourceforge/ganttproject/DesktopIntegration.java
+++ b/ganttproject/src/main/java/net/sourceforge/ganttproject/DesktopIntegration.java
@@ -11,6 +11,7 @@ import net.sourceforge.ganttproject.action.edit.SettingsDialogAction;
 import net.sourceforge.ganttproject.document.Document;
 import net.sourceforge.ganttproject.gui.ProjectUIFacade;
 import net.sourceforge.ganttproject.gui.UIFacade;
+import net.sourceforge.ganttproject.gui.projectopen.ErrorHandlingKt;
 
 import java.io.File;
 import java.io.IOException;
@@ -60,7 +61,11 @@ public class DesktopIntegration {
               if (result) {
                 Document myDocument = project.getDocumentManager().getDocument(file.getAbsolutePath());
                 try {
-                  projectUiFacade.openProject(myDocument, project, null);
+                  var sm = projectUiFacade.openProject(myDocument, project, null);
+                  sm.getStateFailed().await(error -> {
+                    ErrorHandlingKt.showProjectOpenErrorDialog(error, myDocument, uiFacade.getNotificationManager());
+                    return Unit.INSTANCE;
+                  });
                 } catch (Document.DocumentException | IOException ex) {
                   uiFacade.showErrorDialog(ex);
                 }

--- a/ganttproject/src/main/java/net/sourceforge/ganttproject/GanttProject.java
+++ b/ganttproject/src/main/java/net/sourceforge/ganttproject/GanttProject.java
@@ -217,6 +217,7 @@ public class GanttProject extends GanttProjectBase implements ResourceView, Gant
 
     myResourceChartTabContent = new ResourceChartTabContentPanel(getProject(), getUIFacade(),
       myResourceTableSupplier, resourceChart, resourceChart.getCursorProperty(), resourceChart::buildContextMenu);
+    myUiInitializationPromise.activate(getUiFacadeImpl());
 //++
 //    addComponentListener(new ComponentAdapter() {
 //      @Override

--- a/ganttproject/src/main/java/net/sourceforge/ganttproject/GanttProject.java
+++ b/ganttproject/src/main/java/net/sourceforge/ganttproject/GanttProject.java
@@ -271,6 +271,7 @@ public class GanttProject extends GanttProjectBase implements ResourceView, Gant
     startupLogger.debug("8. finalizing...");
     // applyComponentOrientation(GanttLanguage.getInstance()
     // .getComponentOrientation());
+    // TODO: this shall be registered just once
     getProjectUIFacade().getProjectOpenActivityFactory().addListener(
       GanttProjectImplKt.createProjectModificationListener(this, getUIFacade())
     );
@@ -776,4 +777,3 @@ public class GanttProject extends GanttProjectBase implements ResourceView, Gant
   }
 
 }
-

--- a/ganttproject/src/main/java/net/sourceforge/ganttproject/GanttProject.java
+++ b/ganttproject/src/main/java/net/sourceforge/ganttproject/GanttProject.java
@@ -272,7 +272,7 @@ public class GanttProject extends GanttProjectBase implements ResourceView, Gant
     // applyComponentOrientation(GanttLanguage.getInstance()
     // .getComponentOrientation());
     // TODO: this shall be registered just once
-    getProjectUIFacade().getProjectOpenActivityFactory().addListener(
+    getProjectUIFacade().getProjectOpenActivityFactory().addBuilder(
       GanttProjectImplKt.createProjectModificationListener(this, getUIFacade())
     );
     //++addMouseListenerToAllContainer(this.getComponents());

--- a/ganttproject/src/main/java/net/sourceforge/ganttproject/GanttProjectBase.java
+++ b/ganttproject/src/main/java/net/sourceforge/ganttproject/GanttProjectBase.java
@@ -109,7 +109,7 @@ abstract class GanttProjectBase implements IGanttProject, UIFacade {
   private final RssFeedChecker myRssChecker;
   final TaskManagerConfigImpl myTaskManagerConfig;
   private final TaskManager myTaskManager;
-  protected final TwoPhaseBarrierImpl<UIFacade> myUiInitializationPromise;
+  protected final TwoPhaseBarrierImpl<UIFacade> myUiInitializationPromise = new TwoPhaseBarrierImpl<>("UI initialization");
   private Updater myUpdater;
   protected final TaskActions myTaskActions;
   private final GanttProjectImpl myProjectImpl;
@@ -252,7 +252,6 @@ abstract class GanttProjectBase implements IGanttProject, UIFacade {
 
     myNotificationManager = new NotificationManagerImpl();
     myUIFacade = new UIFacadeImpl(stage, myNotificationManager, getProject(), this);
-    myUiInitializationPromise = new TwoPhaseBarrierImpl<>("UI initialization", myUIFacade);
 
     GPLogger.setUIFacade(myUIFacade);
     var newTaskActor = new NewTaskActor<Task>();
@@ -267,9 +266,11 @@ abstract class GanttProjectBase implements IGanttProject, UIFacade {
         return myTaskTableSupplier.get().getActionConnector();
       }
     }, newTaskActor, myProjectDatabase);
+
+    var uiInitializationEntrance = myUiInitializationPromise.register("Task table initialization");
     myTaskTableSupplier = Suppliers.synchronizedSupplier(Suppliers.memoize(() ->
       new TaskTable(getProject(), getTaskManager(), myTaskTableChartConnector, myTaskCollapseView,
-        getTaskSelectionManager(), myTaskActions, getUndoManager(), getTaskFilterManager(), myUiInitializationPromise,
+        getTaskSelectionManager(), myTaskActions, getUndoManager(), getTaskFilterManager(), uiInitializationEntrance,
         newTaskActor, getProjectUIFacade().getProjectOpenActivityFactory())
     ));
     myResourceActions = new ResourceActionSet(getUIFacade().getResourceSelectionManager(), getUIFacade().getResourceSelectionManager(), getProject(), getUIFacade());

--- a/ganttproject/src/main/java/net/sourceforge/ganttproject/GanttProjectImpl.kt
+++ b/ganttproject/src/main/java/net/sourceforge/ganttproject/GanttProjectImpl.kt
@@ -53,7 +53,6 @@ import net.sourceforge.ganttproject.task.event.createTaskListenerWithTimerBarrie
 import java.awt.Color
 import java.io.IOException
 import java.net.URL
-import javax.swing.SwingUtilities
 
 fun interface ErrorUi {
   fun show(ex: Exception)
@@ -291,7 +290,7 @@ internal fun <T> (IGanttProject).restoreProject(listeners: List<ProjectEventList
 }
 
 
-internal fun createProjectModificationListener(project: IGanttProject, uiFacade: UIFacade): ProjectOpenActivityListener {
+internal fun createProjectModificationListener(project: IGanttProject, uiFacade: UIFacade): ProjectOpenStateMachineBuilder {
   val timerBarrier = TimerBarrier(1000).apply {
     await {
       project.setModified()

--- a/ganttproject/src/main/java/net/sourceforge/ganttproject/GanttProjectImpl.kt
+++ b/ganttproject/src/main/java/net/sourceforge/ganttproject/GanttProjectImpl.kt
@@ -149,7 +149,7 @@ open class GanttProjectImpl(
     for (l in listeners) {
       l.projectOpened(barrier, barrier)
     }
-    barrier.isActive = true
+    barrier.activate(this)
   }
 
   @Throws(Document.DocumentException::class, IOException::class)

--- a/ganttproject/src/main/java/net/sourceforge/ganttproject/GanttProjectImpl.kt
+++ b/ganttproject/src/main/java/net/sourceforge/ganttproject/GanttProjectImpl.kt
@@ -312,6 +312,9 @@ internal fun createProjectModificationListener(project: IGanttProject, uiFacade:
       timerBarrier.isPaused = false
       project.isModified = false
     }
+    stateMachine.stateCancelled.await {
+      timerBarrier.isPaused = false
+    }
     stateMachine.stateFailed.await {
       timerBarrier.isPaused = false
     }

--- a/ganttproject/src/main/java/net/sourceforge/ganttproject/ProjectOpenStateMachine.kt
+++ b/ganttproject/src/main/java/net/sourceforge/ganttproject/ProjectOpenStateMachine.kt
@@ -169,7 +169,7 @@ class ProjectOpenStateMachine(val project: IGanttProject, val scope: CoroutineSc
         }
       }
       is ProjectOpenActivityCompleted -> {
-        doSetState(field is ProjectOpenActivityCalculatedModelReady, state) {
+        doSetState(field is ProjectOpenActivityCalculatedModelReady || field is ProjectOpenActivityDocumentForked, state) {
           stateCompleted.resolve(state)
         }
       }
@@ -227,6 +227,10 @@ class ProjectOpenStateMachine(val project: IGanttProject, val scope: CoroutineSc
 
   fun start(document: Document) {
     state = ProjectOpenActivityStarted(document)
+  }
+
+  fun cancel() {
+    state = ProjectOpenActivityCompleted()
   }
 }
 

--- a/ganttproject/src/main/java/net/sourceforge/ganttproject/ProjectOpenStateMachine.kt
+++ b/ganttproject/src/main/java/net/sourceforge/ganttproject/ProjectOpenStateMachine.kt
@@ -83,6 +83,9 @@ class ProjectOpenActivityCalculatedModelReady(val project: IGanttProject, val do
 /** The state when the whole process is completed */
 class ProjectOpenActivityCompleted(val project: IGanttProject, val document: Document) : ProjectOpenActivityState("completed")
 
+/** The state when the user cancels the project opening process, e.g. in the fork resolution dialog. */
+class ProjectOpenActivityCancelled(val project: IGanttProject, val document: Document) : ProjectOpenActivityState("cancelled")
+
 /**
  * This state indicates that the activity has failed.
  */
@@ -102,6 +105,8 @@ class ProjectOpenStateMachine(val project: IGanttProject, val scope: CoroutineSc
   val stateStarted = SimpleBarrier<ProjectOpenActivityStarted>()
   // The project opening process completed successfully. It is okay to close the UI that might be waiting for the result.
   val stateCompleted = SimpleBarrier<ProjectOpenActivityCompleted>()
+  // The project opening process was cancelled by the user. It is okay to close the UI that might be waiting for the result.
+  val stateCancelled = SimpleBarrier<ProjectOpenActivityCancelled>()
   // We need authentication to proceed with the project opening process.
   val stateAuthRequired = SimpleBarrier<ProjectOpenActivityAuthRequired>()
   // The document has been forked, and we may need to take a decision on how to proceed.
@@ -176,6 +181,11 @@ class ProjectOpenStateMachine(val project: IGanttProject, val scope: CoroutineSc
       is ProjectOpenActivityCompleted -> {
         doSetState(field is ProjectOpenActivityCalculatedModelReady || field is ProjectOpenActivityDocumentForked, state) {
           stateCompleted.resolve(state)
+        }
+      }
+      is ProjectOpenActivityCancelled -> {
+        doSetState(field is ProjectOpenActivityDocumentForked, state) {
+          stateCancelled.resolve(state)
         }
       }
       else -> {

--- a/ganttproject/src/main/java/net/sourceforge/ganttproject/ProjectOpenStateMachine.kt
+++ b/ganttproject/src/main/java/net/sourceforge/ganttproject/ProjectOpenStateMachine.kt
@@ -22,6 +22,7 @@ import biz.ganttproject.app.Barrier
 import biz.ganttproject.app.SimpleBarrier
 import biz.ganttproject.app.TwoPhaseBarrierImpl
 import biz.ganttproject.app.i18n
+import biz.ganttproject.storage.FetchResult
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import net.sourceforge.ganttproject.document.Document
@@ -47,6 +48,36 @@ class ProjectOpenActivityStarted : ProjectOpenActivityState("started")
 class ProjectOpenActivityDocumentReady(val document: Document): ProjectOpenActivityState(ID) {
   companion object {
     val ID = "documentReady"
+  }
+}
+
+class ProjectOpenActivityOfflineAhead(val document: Document, val fetchResult: FetchResult): ProjectOpenActivityState(ID) {
+  companion object {
+    val ID = "offlineDocumentIsAhead"
+  }
+}
+
+class ProjectOpenActivityDocumentForked(val document: Document, val fetchResult: FetchResult): ProjectOpenActivityState(ID) {
+  companion object {
+    val ID = "documentForked"
+  }
+}
+
+class ProjectOpenActivityAuthRequired(val document: Document): ProjectOpenActivityState(ID) {
+  companion object {
+    val ID = "authRequired"
+  }
+}
+
+class ProjectOpenActivityPaymentRequired(val document: Document): ProjectOpenActivityState(ID) {
+  companion object {
+    val ID = "paymentRequired"
+  }
+}
+
+class ProjectOpenActivityUnsupportedFormat(val document: Document): ProjectOpenActivityState(ID) {
+  companion object {
+    val ID = "unsupportedFormat"
   }
 }
 

--- a/ganttproject/src/main/java/net/sourceforge/ganttproject/ProjectOpenStateMachine.kt
+++ b/ganttproject/src/main/java/net/sourceforge/ganttproject/ProjectOpenStateMachine.kt
@@ -248,9 +248,11 @@ class ProjectOpenStateMachine(val project: IGanttProject, val scope: CoroutineSc
 typealias ProjectOpenStateMachineBuilder = (ProjectOpenStateMachine) -> Unit
 
 /**
- * This class creates project open activities. A new activity is created when GanttProject opens a project
- * document. Listeners receive an instance of the state machine and can subscribe to the state changes
+ * This object creates project open activities. A new activity is created when GanttProject opens a project
+ * document. Builders receive an instance of the state machine and can subscribe to the state changes
  * and run the appropriate code when a state machine enters into the state they are waiting for.
+ *
+ * This is a singleton, so builders shall be registered wisely, just one per application run.
  */
 object ProjectOpenActivityFactory {
   private val builders = mutableListOf<ProjectOpenStateMachineBuilder>()

--- a/ganttproject/src/main/java/net/sourceforge/ganttproject/ProjectOpenStateMachine.kt
+++ b/ganttproject/src/main/java/net/sourceforge/ganttproject/ProjectOpenStateMachine.kt
@@ -75,13 +75,13 @@ class ProjectOpenActivityMainModelReady(val document: Document) : ProjectOpenAct
 }
 
 /** This is the state when task and resource tables are filled with the project data */
-class ProjectOpenActivityTablesReady(val project: IGanttProject) : ProjectOpenActivityState("tablesReady")
+class ProjectOpenActivityTablesReady(val project: IGanttProject, val document: Document) : ProjectOpenActivityState("tablesReady")
 
 /** This is the state when calculated properties and filters are applied to the project data */
-class ProjectOpenActivityCalculatedModelReady(val project: IGanttProject) : ProjectOpenActivityState("calculatedModelReady")
+class ProjectOpenActivityCalculatedModelReady(val project: IGanttProject, val document: Document) : ProjectOpenActivityState("calculatedModelReady")
 
 /** The state when the whole process is completed */
-class ProjectOpenActivityCompleted: ProjectOpenActivityState("completed")
+class ProjectOpenActivityCompleted(val project: IGanttProject, val document: Document) : ProjectOpenActivityState("completed")
 
 /**
  * This state indicates that the activity has failed.
@@ -109,7 +109,7 @@ class ProjectOpenStateMachine(val project: IGanttProject, val scope: CoroutineSc
   // The document has been successfully loaded and is ready for further processing.
   val stateDocumentReady = SimpleBarrier<ProjectOpenActivityDocumentReady>()
   val stateMainModelReady = SimpleBarrier<ProjectOpenActivityMainModelReady>()
-  val stateTablesReady = TwoPhaseBarrierImpl("Tables Initialized", ProjectOpenActivityTablesReady(project)).also { barrier ->
+  val stateTablesReady = TwoPhaseBarrierImpl<ProjectOpenActivityTablesReady>("Tables Initialized").also { barrier ->
     barrier.await {
       state = it
     }
@@ -162,6 +162,7 @@ class ProjectOpenStateMachine(val project: IGanttProject, val scope: CoroutineSc
       is ProjectOpenActivityMainModelReady -> {
         doSetState(field is ProjectOpenActivityDocumentReady, state) {
           stateMainModelReady.resolve(state)
+          stateTablesReady.activate(ProjectOpenActivityTablesReady(project, state.document))
         }
       }
       is ProjectOpenActivityTablesReady -> {
@@ -231,10 +232,6 @@ class ProjectOpenStateMachine(val project: IGanttProject, val scope: CoroutineSc
 
   fun start(document: Document) {
     state = ProjectOpenActivityStarted(document)
-  }
-
-  fun cancel() {
-    state = ProjectOpenActivityCompleted()
   }
 }
 

--- a/ganttproject/src/main/java/net/sourceforge/ganttproject/ProjectOpenStateMachine.kt
+++ b/ganttproject/src/main/java/net/sourceforge/ganttproject/ProjectOpenStateMachine.kt
@@ -233,7 +233,7 @@ typealias ProjectOpenActivityListener = (ProjectOpenStateMachine) -> Unit
  * document. Listeners receive an instance of the state machine and can subscribe to the state changes
  * and run the appropriate code when a state machine enters into the state they are waiting for.
  */
-class ProjectOpenActivityFactory {
+object ProjectOpenActivityFactory {
   private val listeners = mutableListOf<ProjectOpenActivityListener>()
   fun addListener(l: ProjectOpenActivityListener) = listeners.add(l)
 
@@ -244,6 +244,7 @@ class ProjectOpenActivityFactory {
     }
   }
 }
+
 
 private val i18n = i18n {
   default()

--- a/ganttproject/src/main/java/net/sourceforge/ganttproject/ProjectOpenStateMachine.kt
+++ b/ganttproject/src/main/java/net/sourceforge/ganttproject/ProjectOpenStateMachine.kt
@@ -40,7 +40,7 @@ sealed class ProjectOpenActivityState(val id: String) {
 class ProjectOpenActivityCreated : ProjectOpenActivityState("created")
 
 /** This is the state when project opening process started. */
-class ProjectOpenActivityStarted : ProjectOpenActivityState("started")
+class ProjectOpenActivityStarted(val document: Document) : ProjectOpenActivityState("started")
 
 /**
  * At this state we have loaded the project document and are ready to proceed with loading the main model.
@@ -97,7 +97,7 @@ class ProjectOpenActivityFailed(
  * States are represented as barriers, and code that is triggered on state transitions can
  * await() on the barriers.
  */
-class ProjectOpenStateMachine(project: IGanttProject, val scope: CoroutineScope) {
+class ProjectOpenStateMachine(val project: IGanttProject, val scope: CoroutineScope) {
   val stateStarted = SimpleBarrier<ProjectOpenActivityStarted>()
   val stateCompleted = SimpleBarrier<ProjectOpenActivityCompleted>()
   val stateAuthRequired = SimpleBarrier<ProjectOpenActivityAuthRequired>()
@@ -224,9 +224,13 @@ class ProjectOpenStateMachine(project: IGanttProject, val scope: CoroutineScope)
 
     )
   }
+
+  fun start(document: Document) {
+    state = ProjectOpenActivityStarted(document)
+  }
 }
 
-typealias ProjectOpenActivityListener = (ProjectOpenStateMachine) -> Unit
+typealias ProjectOpenStateMachineBuilder = (ProjectOpenStateMachine) -> Unit
 
 /**
  * This class creates project open activities. A new activity is created when GanttProject opens a project
@@ -234,13 +238,13 @@ typealias ProjectOpenActivityListener = (ProjectOpenStateMachine) -> Unit
  * and run the appropriate code when a state machine enters into the state they are waiting for.
  */
 object ProjectOpenActivityFactory {
-  private val listeners = mutableListOf<ProjectOpenActivityListener>()
-  fun addListener(l: ProjectOpenActivityListener) = listeners.add(l)
+  private val builders = mutableListOf<ProjectOpenStateMachineBuilder>()
+  fun addBuilder(l: ProjectOpenStateMachineBuilder) = builders.add(l)
 
   fun createStateMachine(project: IGanttProject): ProjectOpenStateMachine {
     val coroutineScope = CoroutineScope(EmptyCoroutineContext)
     return ProjectOpenStateMachine(project, coroutineScope).also { sm ->
-      listeners.forEach { it.invoke(sm) }
+      builders.forEach { it.invoke(sm) }
     }
   }
 }

--- a/ganttproject/src/main/java/net/sourceforge/ganttproject/ProjectOpenStateMachine.kt
+++ b/ganttproject/src/main/java/net/sourceforge/ganttproject/ProjectOpenStateMachine.kt
@@ -68,7 +68,7 @@ class ProjectOpenActivityAuthRequired(val document: Document): ProjectOpenActivi
  * At this state we have loaded the task and resource models from the document and have run all possible
  * checks that run on project opening, such as initial re-scheduling.
  */
-class ProjectOpenActivityMainModelReady: ProjectOpenActivityState(ID) {
+class ProjectOpenActivityMainModelReady(val document: Document) : ProjectOpenActivityState(ID) {
   companion object {
     val ID = "mainModelReady"
   }
@@ -93,16 +93,20 @@ class ProjectOpenActivityFailed(
 ): ProjectOpenActivityState("failed")
 
 /**
- * The state machine that manages the states.
+ * The state machine that manages the states of the project opening process.
  * States are represented as barriers, and code that is triggered on state transitions can
  * await() on the barriers.
  */
 class ProjectOpenStateMachine(val project: IGanttProject, val scope: CoroutineScope) {
+  // The project opening process started.
   val stateStarted = SimpleBarrier<ProjectOpenActivityStarted>()
+  // The project opening process completed successfully. It is okay to close the UI that might be waiting for the result.
   val stateCompleted = SimpleBarrier<ProjectOpenActivityCompleted>()
+  // We need authentication to proceed with the project opening process.
   val stateAuthRequired = SimpleBarrier<ProjectOpenActivityAuthRequired>()
-
+  // The document has been forked, and we may need to take a decision on how to proceed.
   val stateDocumentForked = SimpleBarrier<ProjectOpenActivityDocumentForked>()
+  // The document has been successfully loaded and is ready for further processing.
   val stateDocumentReady = SimpleBarrier<ProjectOpenActivityDocumentReady>()
   val stateMainModelReady = SimpleBarrier<ProjectOpenActivityMainModelReady>()
   val stateTablesReady = TwoPhaseBarrierImpl("Tables Initialized", ProjectOpenActivityTablesReady(project)).also { barrier ->

--- a/ganttproject/src/main/java/net/sourceforge/ganttproject/ProjectOpenStateMachine.kt
+++ b/ganttproject/src/main/java/net/sourceforge/ganttproject/ProjectOpenStateMachine.kt
@@ -18,10 +18,13 @@ along with GanttProject.  If not, see <http://www.gnu.org/licenses/>.
 */
 package net.sourceforge.ganttproject
 
+import biz.ganttproject.app.Barrier
 import biz.ganttproject.app.SimpleBarrier
 import biz.ganttproject.app.TwoPhaseBarrierImpl
 import biz.ganttproject.app.i18n
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import net.sourceforge.ganttproject.document.Document
 import kotlin.coroutines.EmptyCoroutineContext
 
 /**
@@ -39,10 +42,23 @@ class ProjectOpenActivityCreated : ProjectOpenActivityState("created")
 class ProjectOpenActivityStarted : ProjectOpenActivityState("started")
 
 /**
+ * At this state we have loaded the project document and are ready to proceed with loading the main model.
+ */
+class ProjectOpenActivityDocumentReady(val document: Document): ProjectOpenActivityState(ID) {
+  companion object {
+    val ID = "documentReady"
+  }
+}
+
+/**
  * At this state we have loaded the task and resource models from the document and have run all possible
  * checks that run on project opening, such as initial re-scheduling.
  */
-class ProjectOpenActivityMainModelReady: ProjectOpenActivityState("mainModelReady")
+class ProjectOpenActivityMainModelReady: ProjectOpenActivityState(ID) {
+  companion object {
+    val ID = "mainModelReady"
+  }
+}
 
 /** This is the state when task and resource tables are filled with the project data */
 class ProjectOpenActivityTablesReady(val project: IGanttProject) : ProjectOpenActivityState("tablesReady")
@@ -70,6 +86,8 @@ class ProjectOpenActivityFailed(
 class ProjectOpenStateMachine(project: IGanttProject, val scope: CoroutineScope) {
   val stateStarted = SimpleBarrier<ProjectOpenActivityStarted>()
   val stateCompleted = SimpleBarrier<ProjectOpenActivityCompleted>()
+
+  val stateDocumentReady = SimpleBarrier<ProjectOpenActivityDocumentReady>()
   val stateMainModelReady = SimpleBarrier<ProjectOpenActivityMainModelReady>()
   val stateTablesReady = TwoPhaseBarrierImpl("Tables Initialized", ProjectOpenActivityTablesReady(project)).also { barrier ->
     barrier.await {
@@ -106,8 +124,13 @@ class ProjectOpenStateMachine(project: IGanttProject, val scope: CoroutineScope)
           stateFailed.resolve(state)
         }
       }
-      is ProjectOpenActivityMainModelReady -> {
+      is ProjectOpenActivityDocumentReady -> {
         doSetState(field is ProjectOpenActivityStarted, state) {
+          stateDocumentReady.resolve(state)
+        }
+      }
+      is ProjectOpenActivityMainModelReady -> {
+        doSetState(field is ProjectOpenActivityDocumentReady, state) {
           stateMainModelReady.resolve(state)
         }
       }
@@ -130,7 +153,27 @@ class ProjectOpenStateMachine(project: IGanttProject, val scope: CoroutineScope)
     }
   }
 
-  fun transition(targetState: ProjectOpenActivityState, code:()->Unit) {
+  fun <Source : ProjectOpenActivityState, Target : ProjectOpenActivityState> transition(
+    fromState: Barrier<Source>,
+    toStateId: String,
+    code: suspend (Source) -> Target
+  ) {
+    fromState.await { value ->
+      scope.launch {
+        state = try {
+          code(value)
+        } catch (ex: Throwable) {
+          ProjectOpenActivityFailed(
+                errorTitle = i18n.formatText("error.title"),
+                errorDescription = i18n.formatText("error.state.${toStateId}", ex.message ?: ""),
+                throwable = ex
+          )
+        }
+      }
+    }
+  }
+
+  fun transition(targetState: ProjectOpenActivityState, code: ()->Unit) {
     try {
       code()
       state = targetState

--- a/ganttproject/src/main/java/net/sourceforge/ganttproject/ProjectOpenStateMachine.kt
+++ b/ganttproject/src/main/java/net/sourceforge/ganttproject/ProjectOpenStateMachine.kt
@@ -118,6 +118,7 @@ class ProjectOpenStateMachine(project: IGanttProject, val scope: CoroutineScope)
   val stateStarted = SimpleBarrier<ProjectOpenActivityStarted>()
   val stateCompleted = SimpleBarrier<ProjectOpenActivityCompleted>()
 
+  val stateAuthRequired = SimpleBarrier<ProjectOpenActivityAuthRequired>()
   val stateDocumentReady = SimpleBarrier<ProjectOpenActivityDocumentReady>()
   val stateMainModelReady = SimpleBarrier<ProjectOpenActivityMainModelReady>()
   val stateTablesReady = TwoPhaseBarrierImpl("Tables Initialized", ProjectOpenActivityTablesReady(project)).also { barrier ->
@@ -155,6 +156,11 @@ class ProjectOpenStateMachine(project: IGanttProject, val scope: CoroutineScope)
           stateFailed.resolve(state)
         }
       }
+      is ProjectOpenActivityAuthRequired -> {
+        doSetState(field is ProjectOpenActivityStarted, state) {
+          stateAuthRequired.resolve(state)
+        }
+      }
       is ProjectOpenActivityDocumentReady -> {
         doSetState(field is ProjectOpenActivityStarted, state) {
           stateDocumentReady.resolve(state)
@@ -179,7 +185,7 @@ class ProjectOpenStateMachine(project: IGanttProject, val scope: CoroutineScope)
         }
       }
       else -> {
-        error("Unexpected state: $state")
+        stateFailed.resolve(ProjectOpenActivityFailed("Unexpected state", "Unexpected state: $state"))
       }
     }
   }

--- a/ganttproject/src/main/java/net/sourceforge/ganttproject/ProjectOpenStateMachine.kt
+++ b/ganttproject/src/main/java/net/sourceforge/ganttproject/ProjectOpenStateMachine.kt
@@ -51,13 +51,8 @@ class ProjectOpenActivityDocumentReady(val document: Document): ProjectOpenActiv
   }
 }
 
-class ProjectOpenActivityOfflineAhead(val document: Document, val fetchResult: FetchResult): ProjectOpenActivityState(ID) {
-  companion object {
-    val ID = "offlineDocumentIsAhead"
-  }
-}
-
-class ProjectOpenActivityDocumentForked(val document: Document, val fetchResult: FetchResult): ProjectOpenActivityState(ID) {
+class ProjectOpenActivityDocumentForked(val document: Document, val fetchResult: FetchResult, val forkCase: ForkCase): ProjectOpenActivityState(ID) {
+  enum class ForkCase { FORK, OFFLINE_AHEAD }
   companion object {
     val ID = "documentForked"
   }
@@ -66,18 +61,6 @@ class ProjectOpenActivityDocumentForked(val document: Document, val fetchResult:
 class ProjectOpenActivityAuthRequired(val document: Document): ProjectOpenActivityState(ID) {
   companion object {
     val ID = "authRequired"
-  }
-}
-
-class ProjectOpenActivityPaymentRequired(val document: Document): ProjectOpenActivityState(ID) {
-  companion object {
-    val ID = "paymentRequired"
-  }
-}
-
-class ProjectOpenActivityUnsupportedFormat(val document: Document): ProjectOpenActivityState(ID) {
-  companion object {
-    val ID = "unsupportedFormat"
   }
 }
 
@@ -117,8 +100,9 @@ class ProjectOpenActivityFailed(
 class ProjectOpenStateMachine(project: IGanttProject, val scope: CoroutineScope) {
   val stateStarted = SimpleBarrier<ProjectOpenActivityStarted>()
   val stateCompleted = SimpleBarrier<ProjectOpenActivityCompleted>()
-
   val stateAuthRequired = SimpleBarrier<ProjectOpenActivityAuthRequired>()
+
+  val stateDocumentForked = SimpleBarrier<ProjectOpenActivityDocumentForked>()
   val stateDocumentReady = SimpleBarrier<ProjectOpenActivityDocumentReady>()
   val stateMainModelReady = SimpleBarrier<ProjectOpenActivityMainModelReady>()
   val stateTablesReady = TwoPhaseBarrierImpl("Tables Initialized", ProjectOpenActivityTablesReady(project)).also { barrier ->
@@ -147,7 +131,7 @@ class ProjectOpenStateMachine(project: IGanttProject, val scope: CoroutineScope)
     }
     when (state) {
       is ProjectOpenActivityStarted -> {
-        doSetState(field is ProjectOpenActivityCreated, state) {
+        doSetState(field is ProjectOpenActivityCreated || field is ProjectOpenActivityAuthRequired, state) {
           stateStarted.resolve(state)
         }
       }
@@ -161,8 +145,13 @@ class ProjectOpenStateMachine(project: IGanttProject, val scope: CoroutineScope)
           stateAuthRequired.resolve(state)
         }
       }
-      is ProjectOpenActivityDocumentReady -> {
+      is ProjectOpenActivityDocumentForked -> {
         doSetState(field is ProjectOpenActivityStarted, state) {
+          stateDocumentForked.resolve(state)
+        }
+      }
+      is ProjectOpenActivityDocumentReady -> {
+        doSetState(field is ProjectOpenActivityStarted || field is ProjectOpenActivityDocumentForked, state) {
           stateDocumentReady.resolve(state)
         }
       }

--- a/ganttproject/src/main/java/net/sourceforge/ganttproject/action/help/HelpMenu.java
+++ b/ganttproject/src/main/java/net/sourceforge/ganttproject/action/help/HelpMenu.java
@@ -19,6 +19,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 package net.sourceforge.ganttproject.action.help;
 
 import biz.ganttproject.storage.AutoSaveManager;
+import kotlin.Unit;
 import net.sourceforge.ganttproject.GPLogger;
 import net.sourceforge.ganttproject.IGanttProject;
 import net.sourceforge.ganttproject.action.CancelAction;
@@ -31,6 +32,7 @@ import net.sourceforge.ganttproject.gui.ProjectUIFacade;
 import net.sourceforge.ganttproject.gui.UIFacade;
 import net.sourceforge.ganttproject.gui.UIUtil;
 import net.sourceforge.ganttproject.gui.ViewLogDialog;
+import net.sourceforge.ganttproject.gui.projectopen.ErrorHandlingKt;
 import net.sourceforge.ganttproject.language.GanttLanguage;
 
 import javax.swing.*;
@@ -155,7 +157,11 @@ public class HelpMenu {
 
     protected void recover(Document recoverDocument) {
       try {
-        myProjectUiFacade.openProject(new ReadOnlyProxyDocument(recoverDocument), myProject, null);
+        var sm = myProjectUiFacade.openProject(new ReadOnlyProxyDocument(recoverDocument), myProject, null);
+        sm.getStateFailed().await(error -> {
+          ErrorHandlingKt.showProjectOpenErrorDialog(error, new ReadOnlyProxyDocument(recoverDocument), myUiFacade.getNotificationManager());
+          return Unit.INSTANCE;
+        });
       } catch (Throwable e) {
         GPLogger.log(new RuntimeException("Failed to recover file " + recoverDocument.getFileName(), e));
       }

--- a/ganttproject/src/main/java/net/sourceforge/ganttproject/action/help/HelpMenu.java
+++ b/ganttproject/src/main/java/net/sourceforge/ganttproject/action/help/HelpMenu.java
@@ -155,7 +155,7 @@ public class HelpMenu {
 
     protected void recover(Document recoverDocument) {
       try {
-        myProjectUiFacade.openProject(new ReadOnlyProxyDocument(recoverDocument), myProject, null, null);
+        myProjectUiFacade.openProject(new ReadOnlyProxyDocument(recoverDocument), myProject, null);
       } catch (Throwable e) {
         GPLogger.log(new RuntimeException("Failed to recover file " + recoverDocument.getFileName(), e));
       }

--- a/ganttproject/src/main/java/net/sourceforge/ganttproject/gui/ProjectOpenStrategy.kt
+++ b/ganttproject/src/main/java/net/sourceforge/ganttproject/gui/ProjectOpenStrategy.kt
@@ -125,6 +125,11 @@ internal class ProjectOpenStrategy(
       stateMachine.state = ProjectOpenActivityDocumentReady(document)
       return
     }
+    stateMachine.stateAuthRequired.await {
+      signin.invoke {
+        println("success!!!")
+      }
+    }
     stateMachine.scope.launch {
       withContext(Dispatchers.IO) {
         try {

--- a/ganttproject/src/main/java/net/sourceforge/ganttproject/gui/ProjectOpenStrategy.kt
+++ b/ganttproject/src/main/java/net/sourceforge/ganttproject/gui/ProjectOpenStrategy.kt
@@ -23,6 +23,8 @@ import biz.ganttproject.app.RootLocalizer
 import biz.ganttproject.core.option.DefaultEnumerationOption
 import biz.ganttproject.core.time.TimeDuration
 import biz.ganttproject.storage.*
+import biz.ganttproject.storage.cloud.GPCloudDocument
+import biz.ganttproject.storage.cloud.installOfflineMirror
 import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.Result
@@ -190,6 +192,7 @@ internal class ProjectOpenStrategy(
 
   private fun processFetchResult(fetchResult: FetchResult, document: Document): Result<Document, ProjectOpenActivityState> {
     val onlineDoc = fetchResult.onlineDocument
+    (onlineDoc as? GPCloudDocument)?.installOfflineMirror(project.documentManager)
     val mirrorDoc = onlineDoc.offlineMirror
     val offlineChecksum = mirrorDoc?.checksum() ?: return Ok(document)
 

--- a/ganttproject/src/main/java/net/sourceforge/ganttproject/gui/ProjectOpenStrategy.kt
+++ b/ganttproject/src/main/java/net/sourceforge/ganttproject/gui/ProjectOpenStrategy.kt
@@ -108,9 +108,6 @@ internal class ProjectOpenStrategy(
     }
   }
 
-  private val openScope = CoroutineScope(Executors.newFixedThreadPool(3).asCoroutineDispatcher())
-  private val sendingScope = CoroutineScope(Executors.newSingleThreadExecutor().asCoroutineDispatcher())
-
   fun start(document: Document) {
     val onlineDocument = document.asOnlineDocument() ?: run {
       stateMachine.state = ProjectOpenActivityDocumentReady(document)
@@ -139,54 +136,6 @@ internal class ProjectOpenStrategy(
           ))
         } catch (ex: Exception) {
           stateMachine.fail(ex)
-        }
-      }
-    }
-  }
-
-  fun open(document: Document, docChannel: Channel<Document>) {
-    val localChannel = Channel<Document>()
-    openScope.launch {
-      // Here we wait until the document is fetched, either from the cloud or locally.
-      try {
-        localChannel.receive().also {
-          //TODO
-          it.checkWellFormed()
-          // If the document was fetched successfully and it is well-formed, it is okay to send it to the document
-          // channel.
-          docChannel.send(it)
-        }
-      } catch (ex: ForbiddenException) {
-        // It is possible that we need to sign into GP Cloud to open a document.
-        signin { open(document, docChannel) }
-      } catch (ex: PaymentRequiredException) {
-        // Or probably we need to pay.
-        docChannel.close(ex)
-      } catch (ex: SAXException) {
-        // It is also possible that the document can't be parsed as XML.
-        docChannel.close(Document.DocumentException(
-          RootLocalizer.formatText("document.error.read.unsupportedFormat"), ex
-        ))
-      } catch (ex: Exception) {
-        docChannel.close(ex)
-      }
-    }
-    openScope.launch {
-      // In this coroutine we check if it is an online document and fetch it.
-      val online = document.asOnlineDocument()
-      if (online == null) {
-        // It is a local document, just send it to the next stage.
-        localChannel.send(document)
-      } else {
-        // It is an online document and we fetch it.
-        try {
-          val currentFetch = online.fetchResultProperty.get() ?: online.fetch().also { it.update() }
-          processFetchResult(currentFetch, document).fold(
-            success = { doc -> stateMachine.state = ProjectOpenActivityDocumentReady(doc)},
-            failure = { stateMachine.state = it }
-          )
-        } catch (ex: Exception) {
-          localChannel.close(ex)
         }
       }
     }
@@ -473,6 +422,9 @@ internal class CommandLineProjectOpenStrategy(
     projectUiFacade.openProject(document, project, null).apply {
       stateCompleted.await {
         DOCUMENT_LOGGER.debug("<<< openStartupDocument($path)")
+      }
+      stateCancelled.await {
+        DOCUMENT_LOGGER.debug("<<< openStartupDocument($path) cancelled")
       }
       stateFailed.await { it ->
         if (it.throwable is Document.DocumentException) {

--- a/ganttproject/src/main/java/net/sourceforge/ganttproject/gui/ProjectOpenStrategy.kt
+++ b/ganttproject/src/main/java/net/sourceforge/ganttproject/gui/ProjectOpenStrategy.kt
@@ -19,8 +19,6 @@ along with GanttProject.  If not, see <http://www.gnu.org/licenses/>.
 */
 package net.sourceforge.ganttproject.gui
 
-import biz.ganttproject.app.OptionElementData
-import biz.ganttproject.app.OptionPaneBuilder
 import biz.ganttproject.app.RootLocalizer
 import biz.ganttproject.core.option.DefaultEnumerationOption
 import biz.ganttproject.core.time.TimeDuration
@@ -30,22 +28,11 @@ import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.fold
 import com.google.common.collect.Lists
-import de.jensd.fx.glyphs.fontawesome.FontAwesomeIcon
-import de.jensd.fx.glyphs.fontawesome.FontAwesomeIconView
 import javafx.beans.value.ChangeListener
 import javafx.beans.value.ObservableValue
 import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.Channel
-import net.sourceforge.ganttproject.GPLogger
-import net.sourceforge.ganttproject.IGanttProject
-import net.sourceforge.ganttproject.ProjectOpenActivityAuthRequired
-import net.sourceforge.ganttproject.ProjectOpenActivityDocumentForked
-import net.sourceforge.ganttproject.ProjectOpenActivityDocumentReady
-import net.sourceforge.ganttproject.ProjectOpenActivityOfflineAhead
-import net.sourceforge.ganttproject.ProjectOpenActivityPaymentRequired
-import net.sourceforge.ganttproject.ProjectOpenActivityState
-import net.sourceforge.ganttproject.ProjectOpenActivityUnsupportedFormat
-import net.sourceforge.ganttproject.ProjectOpenStateMachine
+import net.sourceforge.ganttproject.*
 import net.sourceforge.ganttproject.action.GPAction
 import net.sourceforge.ganttproject.action.OkAction
 import net.sourceforge.ganttproject.document.Document
@@ -125,11 +112,6 @@ internal class ProjectOpenStrategy(
       stateMachine.state = ProjectOpenActivityDocumentReady(document)
       return
     }
-    stateMachine.stateAuthRequired.await {
-      signin.invoke {
-        println("success!!!")
-      }
-    }
     stateMachine.scope.launch {
       withContext(Dispatchers.IO) {
         try {
@@ -139,36 +121,22 @@ internal class ProjectOpenStrategy(
             failure = { stateMachine.state = it }
           )
         } catch (ex: ForbiddenException) {
+          DOCUMENT_ERROR_LOGGER.error("Access to document {} forbidden: {}", onlineDocument, ex.message.orEmpty())
           // It is possible that we need to sign into GP Cloud to open a document.
           stateMachine.state = ProjectOpenActivityAuthRequired(document)
-          //TODO
-          //signin { open(document, docChannel) }
         } catch (ex: PaymentRequiredException) {
           // Or probably we need to pay.
-          stateMachine.state = ProjectOpenActivityPaymentRequired(document)
-          //TODO
-          //docChannel.close(ex)
+          DOCUMENT_ERROR_LOGGER.error("Access to document {} permitted, but payment is required", onlineDocument)
+          stateMachine.fail(ex)
         } catch (ex: SAXException) {
           // It is also possible that the document can't be parsed as XML.
-          stateMachine.state = ProjectOpenActivityUnsupportedFormat(document)
-          //TODO
-//          docChannel.close(Document.DocumentException(
-//            RootLocalizer.formatText("document.error.read.unsupportedFormat"), ex
-//          ))
+          stateMachine.fail(Document.DocumentException(
+            RootLocalizer.formatText("document.error.read.unsupportedFormat"), ex
+          ))
         } catch (ex: Exception) {
           stateMachine.fail(ex)
-          //docChannel.close(ex)
         }
       }
-    }
-  }
-
-  suspend fun open(document: Document): Document {
-
-    val docChannel = Channel<Document>()
-    open(document, docChannel)
-    return withContext(Dispatchers.IO) {
-      docChannel.receive()
     }
   }
 
@@ -234,97 +202,18 @@ internal class ProjectOpenStrategy(
       // This is the case when we have local modifications not yet written online,
       // e.g. because we have been offline for a while and went online
       // when GP was closed.
-      return Err(ProjectOpenActivityOfflineAhead(document, fetchResult))
-      // TODO
-      //showOfflineIsAheadDialog(fetchResult, document, successChannel)
+      return Err(ProjectOpenActivityDocumentForked(document, fetchResult, ProjectOpenActivityDocumentForked.ForkCase.OFFLINE_AHEAD))
     } else {
       // Online is different from mirror, and we have to find out if we had
       // any offline modifications.
       if (offlineChecksum == fetchResult.syncChecksum) {
-        //successChannel.send(document)
         return Ok(document)
       } else {
         // Files modified both locally and online. Ask user which one wins
-        return Err(ProjectOpenActivityDocumentForked(document, fetchResult))
-        // TODO
-        //showForkDialog(fetchResult, document, successChannel)
+        return Err(ProjectOpenActivityDocumentForked(document, fetchResult, ProjectOpenActivityDocumentForked.ForkCase.FORK))
       }
     }
   }
-
-  enum class OpenOnlineDocumentChoice { USE_OFFLINE, USE_ONLINE, CANCEL }
-
-  private fun showOfflineIsAheadDialog(fetchResult: FetchResult, document: Document, successChannel: Channel<Document>) {
-    OptionPaneBuilder<OpenOnlineDocumentChoice>().run {
-      i18n = RootLocalizer.createWithRootKey(rootKey = "cloud.openWhenOfflineIsAhead")
-      styleClass = "dlg-lock"
-      styleSheets.add("/biz/ganttproject/storage/cloud/GPCloudStorage.css")
-      styleSheets.add("/biz/ganttproject/storage/StorageDialog.css")
-      graphic = FontAwesomeIconView(FontAwesomeIcon.UNLOCK)
-      elements = listOf(
-          OptionElementData("useOffline", OpenOnlineDocumentChoice.USE_OFFLINE, true),
-          OptionElementData("useOnline", OpenOnlineDocumentChoice.USE_ONLINE),
-          OptionElementData("cancel", OpenOnlineDocumentChoice.CANCEL)
-      )
-
-      showDialog { choice ->
-        when (choice) {
-          OpenOnlineDocumentChoice.USE_OFFLINE -> {
-            fetchResult.useMirror = true
-            sendingScope.launch {
-              successChannel.send(document)
-            }
-          }
-          OpenOnlineDocumentChoice.USE_ONLINE -> {
-            sendingScope.launch {
-              successChannel.send(document)
-            }
-          }
-          OpenOnlineDocumentChoice.CANCEL -> {
-
-          }
-        }
-      }
-    }
-  }
-
-  private fun showForkDialog(fetchResult: FetchResult, document: Document, successChannel: Channel<Document>) {
-    OptionPaneBuilder<OpenOnlineDocumentChoice>().run {
-      i18n = RootLocalizer.createWithRootKey(rootKey = "cloud.openWhenDiverged")
-      styleClass = "dlg-lock"
-      styleSheets.add("/biz/ganttproject/storage/cloud/GPCloudStorage.css")
-      styleSheets.add("/biz/ganttproject/storage/StorageDialog.css")
-      graphic = FontAwesomeIconView(FontAwesomeIcon.UNLOCK)
-      elements = listOf(
-          OptionElementData("useOffline", OpenOnlineDocumentChoice.USE_OFFLINE, true),
-          OptionElementData("useOnline", OpenOnlineDocumentChoice.USE_ONLINE),
-          OptionElementData("cancel", OpenOnlineDocumentChoice.CANCEL)
-      )
-
-      showDialog { choice ->
-        when (choice) {
-          OpenOnlineDocumentChoice.USE_OFFLINE -> {
-            fetchResult.useMirror = true
-            sendingScope.launch {
-              successChannel.send(document)
-            }
-          }
-          OpenOnlineDocumentChoice.USE_ONLINE -> {
-            sendingScope.launch {
-              successChannel.send(document)
-            }
-          }
-          OpenOnlineDocumentChoice.CANCEL -> {
-          }
-        }
-      }
-    }
-  }
-
-  private fun handleDocumentException(ex: Document.DocumentException) {
-    TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
-  }
-
 
   // First we open file "as is", that is, without running any algorithms which
   // change task dates.

--- a/ganttproject/src/main/java/net/sourceforge/ganttproject/gui/ProjectOpenStrategy.kt
+++ b/ganttproject/src/main/java/net/sourceforge/ganttproject/gui/ProjectOpenStrategy.kt
@@ -554,4 +554,3 @@ internal class CommandLineProjectOpenStrategy(
 }
 
 private val DOCUMENT_LOGGER = GPLogger.create("Document.Info")
-private val DOCUMENT_ERROR_LOGGER = GPLogger.create("Document.Error")

--- a/ganttproject/src/main/java/net/sourceforge/ganttproject/gui/ProjectOpenStrategy.kt
+++ b/ganttproject/src/main/java/net/sourceforge/ganttproject/gui/ProjectOpenStrategy.kt
@@ -30,10 +30,10 @@ import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.fold
 import com.google.common.collect.Lists
-import javafx.beans.value.ChangeListener
-import javafx.beans.value.ObservableValue
-import kotlinx.coroutines.*
-import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Runnable
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import net.sourceforge.ganttproject.*
 import net.sourceforge.ganttproject.action.GPAction
 import net.sourceforge.ganttproject.action.OkAction
@@ -55,7 +55,6 @@ import org.xml.sax.SAXException
 import java.awt.BorderLayout
 import java.awt.event.ActionEvent
 import java.io.File
-import java.util.concurrent.Executors
 import java.util.function.Consumer
 import java.util.regex.Pattern
 import javax.swing.*
@@ -355,25 +354,7 @@ internal class ProjectOpenStrategy(
     }
   }
 
-  internal inner class Step4 {
-    fun onFetchResultChange(document: Document, callback: () -> Unit) {
-      val onlineDocument = document.asOnlineDocument()
-      if (onlineDocument != null) {
-        val changeListener = object : ChangeListener<FetchResult?> {
-          override fun changed(observable: ObservableValue<out FetchResult?>?, oldFetch: FetchResult?, newFetch: FetchResult?) {
-            println("oldFetch=${oldFetch?.actualChecksum} newFetch=${newFetch?.actualChecksum}")
-            if (oldFetch != null && newFetch != null) {
-              if (oldFetch.actualVersion != newFetch.actualVersion) {
-                observable?.removeListener(this)
-                callback()
-              }
-            }
-          }
-        }
-        onlineDocument.fetchResultProperty.addListener(changeListener)
-      }
-
-    }
+  internal class Step4 {
   }
   companion object {
     val milestonesOption = DefaultEnumerationOption(
@@ -403,22 +384,6 @@ internal class CommandLineProjectOpenStrategy(
   private fun doOpenStartupDocument(path: String) {
     DOCUMENT_LOGGER.debug(">>> openStartupDocument($path)")
     val document: Document = documentManager.getDocument(path)
-//    val finishChannel = Channel<Boolean>()
-//    CoroutineScope(Executors.newSingleThreadExecutor().asCoroutineDispatcher()).launch {
-//      try {
-//        finishChannel.receive()
-//      } catch (e: Document.DocumentException) {
-//        if (!tryImportDocument(document)) {
-//          uiFacade.showErrorDialog(e)
-//        }
-//      } catch (e: IOException) {
-//        // TODO: shall we try to import a document here? when it may make sense? CSV/MPP ?
-//          uiFacade.showErrorDialog(e)
-//      } catch (e: Exception) {
-//        uiFacade.showErrorDialog(e)
-//      }
-//
-//    }
     projectUiFacade.openProject(document, project, null).apply {
       stateCompleted.await {
         DOCUMENT_LOGGER.debug("<<< openStartupDocument($path)")

--- a/ganttproject/src/main/java/net/sourceforge/ganttproject/gui/ProjectOpenStrategy.kt
+++ b/ganttproject/src/main/java/net/sourceforge/ganttproject/gui/ProjectOpenStrategy.kt
@@ -107,6 +107,14 @@ internal class ProjectOpenStrategy(
   private val openScope = CoroutineScope(Executors.newFixedThreadPool(3).asCoroutineDispatcher())
   private val sendingScope = CoroutineScope(Executors.newSingleThreadExecutor().asCoroutineDispatcher())
 
+  suspend fun open(document: Document): Document {
+    val docChannel = Channel<Document>()
+    open(document, docChannel)
+    return withContext(Dispatchers.IO) {
+      docChannel.receive()
+    }
+  }
+
   fun open(document: Document, docChannel: Channel<Document>) {
     val localChannel = Channel<Document>()
     openScope.launch {

--- a/ganttproject/src/main/java/net/sourceforge/ganttproject/gui/ProjectOpenStrategy.kt
+++ b/ganttproject/src/main/java/net/sourceforge/ganttproject/gui/ProjectOpenStrategy.kt
@@ -25,6 +25,10 @@ import biz.ganttproject.app.RootLocalizer
 import biz.ganttproject.core.option.DefaultEnumerationOption
 import biz.ganttproject.core.time.TimeDuration
 import biz.ganttproject.storage.*
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import com.github.michaelbull.result.Result
+import com.github.michaelbull.result.fold
 import com.google.common.collect.Lists
 import de.jensd.fx.glyphs.fontawesome.FontAwesomeIcon
 import de.jensd.fx.glyphs.fontawesome.FontAwesomeIconView
@@ -34,6 +38,14 @@ import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.Channel
 import net.sourceforge.ganttproject.GPLogger
 import net.sourceforge.ganttproject.IGanttProject
+import net.sourceforge.ganttproject.ProjectOpenActivityAuthRequired
+import net.sourceforge.ganttproject.ProjectOpenActivityDocumentForked
+import net.sourceforge.ganttproject.ProjectOpenActivityDocumentReady
+import net.sourceforge.ganttproject.ProjectOpenActivityOfflineAhead
+import net.sourceforge.ganttproject.ProjectOpenActivityPaymentRequired
+import net.sourceforge.ganttproject.ProjectOpenActivityState
+import net.sourceforge.ganttproject.ProjectOpenActivityUnsupportedFormat
+import net.sourceforge.ganttproject.ProjectOpenStateMachine
 import net.sourceforge.ganttproject.action.GPAction
 import net.sourceforge.ganttproject.action.OkAction
 import net.sourceforge.ganttproject.document.Document
@@ -52,7 +64,6 @@ import org.xml.sax.SAXException
 import java.awt.BorderLayout
 import java.awt.event.ActionEvent
 import java.io.File
-import java.io.IOException
 import java.util.concurrent.Executors
 import java.util.function.Consumer
 import java.util.regex.Pattern
@@ -71,6 +82,7 @@ internal class ProjectOpenStrategy(
   private val project: IGanttProject,
   private val uiFacade: UIFacade,
   private val signin: AuthenticationFlow,
+  private val stateMachine: ProjectOpenStateMachine
   ) : AutoCloseable {
   private val myDiagnostics: ProjectOpenDiagnosticImpl
   private val myCloseables = Lists.newArrayList<AutoCloseable>()
@@ -108,7 +120,46 @@ internal class ProjectOpenStrategy(
   private val openScope = CoroutineScope(Executors.newFixedThreadPool(3).asCoroutineDispatcher())
   private val sendingScope = CoroutineScope(Executors.newSingleThreadExecutor().asCoroutineDispatcher())
 
+  fun start(document: Document) {
+    val onlineDocument = document.asOnlineDocument() ?: run {
+      stateMachine.state = ProjectOpenActivityDocumentReady(document)
+      return
+    }
+    stateMachine.scope.launch {
+      withContext(Dispatchers.IO) {
+        try {
+          val currentFetch = onlineDocument.fetchResultProperty.get() ?: onlineDocument.fetch().also { it.update() }
+          processFetchResult(currentFetch, document).fold(
+            success = { doc -> stateMachine.state = ProjectOpenActivityDocumentReady(doc)},
+            failure = { stateMachine.state = it }
+          )
+        } catch (ex: ForbiddenException) {
+          // It is possible that we need to sign into GP Cloud to open a document.
+          stateMachine.state = ProjectOpenActivityAuthRequired(document)
+          //TODO
+          //signin { open(document, docChannel) }
+        } catch (ex: PaymentRequiredException) {
+          // Or probably we need to pay.
+          stateMachine.state = ProjectOpenActivityPaymentRequired(document)
+          //TODO
+          //docChannel.close(ex)
+        } catch (ex: SAXException) {
+          // It is also possible that the document can't be parsed as XML.
+          stateMachine.state = ProjectOpenActivityUnsupportedFormat(document)
+          //TODO
+//          docChannel.close(Document.DocumentException(
+//            RootLocalizer.formatText("document.error.read.unsupportedFormat"), ex
+//          ))
+        } catch (ex: Exception) {
+          stateMachine.fail(ex)
+          //docChannel.close(ex)
+        }
+      }
+    }
+  }
+
   suspend fun open(document: Document): Document {
+
     val docChannel = Channel<Document>()
     open(document, docChannel)
     return withContext(Dispatchers.IO) {
@@ -122,6 +173,7 @@ internal class ProjectOpenStrategy(
       // Here we wait until the document is fetched, either from the cloud or locally.
       try {
         localChannel.receive().also {
+          //TODO
           it.checkWellFormed()
           // If the document was fetched successfully and it is well-formed, it is okay to send it to the document
           // channel.
@@ -152,7 +204,10 @@ internal class ProjectOpenStrategy(
         // It is an online document and we fetch it.
         try {
           val currentFetch = online.fetchResultProperty.get() ?: online.fetch().also { it.update() }
-          processFetchResult(currentFetch, document, localChannel)
+          processFetchResult(currentFetch, document).fold(
+            success = { doc -> stateMachine.state = ProjectOpenActivityDocumentReady(doc)},
+            failure = { stateMachine.state = it }
+          )
         } catch (ex: Exception) {
           localChannel.close(ex)
         }
@@ -160,34 +215,34 @@ internal class ProjectOpenStrategy(
     }
   }
 
-  private suspend fun processFetchResult(fetchResult: FetchResult, document: Document, successChannel: Channel<Document>) {
+  private fun processFetchResult(fetchResult: FetchResult, document: Document): Result<Document, ProjectOpenActivityState> {
     val onlineDoc = fetchResult.onlineDocument
     val mirrorDoc = onlineDoc.offlineMirror
-    val offlineChecksum = mirrorDoc?.checksum()
-    if (offlineChecksum == null) {
-      successChannel.send(document)
-      return
-    }
+    val offlineChecksum = mirrorDoc?.checksum() ?: return Ok(document)
+
     if (offlineChecksum == fetchResult.actualChecksum) {
       // Offline mirror and actual file online are identical, only version could change
       // Just read the online
-      successChannel.send(document)
-      return
+      return Ok(document)
     }
     if (fetchResult.syncVersion == fetchResult.actualVersion) {
       // This is the case when we have local modifications not yet written online,
       // e.g. because we have been offline for a while and went online
       // when GP was closed.
-      showOfflineIsAheadDialog(fetchResult, document, successChannel)
+      return Err(ProjectOpenActivityOfflineAhead(document, fetchResult))
+      // TODO
+      //showOfflineIsAheadDialog(fetchResult, document, successChannel)
     } else {
       // Online is different from mirror, and we have to find out if we had
       // any offline modifications.
       if (offlineChecksum == fetchResult.syncChecksum) {
-        successChannel.send(document)
-        return
+        //successChannel.send(document)
+        return Ok(document)
       } else {
         // Files modified both locally and online. Ask user which one wins
-        showForkDialog(fetchResult, document, successChannel)
+        return Err(ProjectOpenActivityDocumentForked(document, fetchResult))
+        // TODO
+        //showForkDialog(fetchResult, document, successChannel)
       }
     }
   }
@@ -287,6 +342,7 @@ internal class ProjectOpenStrategy(
     myOldDuration = project.taskManager.projectLength
     return Step1()
   }
+
 
   // This step checks if there are legacy 1-day milestones in the project.
   // If there are legacy milestones, we ask the user what shall we do with them.

--- a/ganttproject/src/main/java/net/sourceforge/ganttproject/gui/ProjectOpenStrategy.kt
+++ b/ganttproject/src/main/java/net/sourceforge/ganttproject/gui/ProjectOpenStrategy.kt
@@ -525,7 +525,7 @@ internal class CommandLineProjectOpenStrategy(
     val recentDocsConsumer = Consumer<List<RecentDocAsFolderItem>> { docList ->
       docList.firstOrNull()?.asDocument()?.let { lastDocument ->
         val stateMachine = projectUiFacade.openProject(
-          project.documentManager.getProxyDocument(lastDocument), project, null, null
+          project.documentManager.getProxyDocument(lastDocument), project, null
         )
         stateMachine.stateFailed.await { error ->
           val msg = """

--- a/ganttproject/src/main/java/net/sourceforge/ganttproject/gui/ProjectOpenStrategy.kt
+++ b/ganttproject/src/main/java/net/sourceforge/ganttproject/gui/ProjectOpenStrategy.kt
@@ -39,6 +39,7 @@ import net.sourceforge.ganttproject.action.OkAction
 import net.sourceforge.ganttproject.document.Document
 import net.sourceforge.ganttproject.document.DocumentManager
 import net.sourceforge.ganttproject.importer.Importer
+import net.sourceforge.ganttproject.importer.ImporterWizardModel
 import net.sourceforge.ganttproject.language.GanttLanguage
 import net.sourceforge.ganttproject.plugins.PluginManager
 import net.sourceforge.ganttproject.task.TaskImpl
@@ -134,9 +135,9 @@ internal class ProjectOpenStrategy(
         docChannel.close(ex)
       } catch (ex: SAXException) {
         // It is also possible that the document can't be parsed as XML.
-        throw Document.DocumentException(
+        docChannel.close(Document.DocumentException(
           RootLocalizer.formatText("document.error.read.unsupportedFormat"), ex
-        )
+        ))
       } catch (ex: Exception) {
         docChannel.close(ex)
       }
@@ -498,26 +499,47 @@ internal class CommandLineProjectOpenStrategy(
   private fun doOpenStartupDocument(path: String) {
     DOCUMENT_LOGGER.debug(">>> openStartupDocument($path)")
     val document: Document = documentManager.getDocument(path)
-    val finishChannel = Channel<Boolean>()
-    CoroutineScope(Executors.newSingleThreadExecutor().asCoroutineDispatcher()).launch {
-      try {
-        finishChannel.receive()
-      } catch (e: Document.DocumentException) {
-        if (!tryImportDocument(document)) {
-          uiFacade.showErrorDialog(e)
-        }
-      } catch (e: IOException) {
-        // TODO: shall we try to import a document here? when it may make sense? CSV/MPP ?
-          uiFacade.showErrorDialog(e)
-      } catch (e: Exception) {
-        uiFacade.showErrorDialog(e)
+//    val finishChannel = Channel<Boolean>()
+//    CoroutineScope(Executors.newSingleThreadExecutor().asCoroutineDispatcher()).launch {
+//      try {
+//        finishChannel.receive()
+//      } catch (e: Document.DocumentException) {
+//        if (!tryImportDocument(document)) {
+//          uiFacade.showErrorDialog(e)
+//        }
+//      } catch (e: IOException) {
+//        // TODO: shall we try to import a document here? when it may make sense? CSV/MPP ?
+//          uiFacade.showErrorDialog(e)
+//      } catch (e: Exception) {
+//        uiFacade.showErrorDialog(e)
+//      }
+//
+//    }
+    projectUiFacade.openProject(document, project, null).apply {
+      stateCompleted.await {
+        DOCUMENT_LOGGER.debug("<<< openStartupDocument($path)")
       }
-      DOCUMENT_LOGGER.debug("<<< openStartupDocument($path)")
+      stateFailed.await { it ->
+        if (it.throwable is Document.DocumentException) {
+          tryImportDocument(document, it.throwable)
+        } else {
+          uiFacade.showErrorDialog(it.throwable)
+        }
+      }
     }
-    projectUiFacade.openProject(document, project, finishChannel)
   }
 
-  private fun tryImportDocument(document: Document): Boolean {
+  private fun tryImportDocument(document: Document, ex: Exception) {
+    try {
+      if (!doTryImportDocument(document)) {
+        uiFacade.showErrorDialog(ex)
+      }
+    } catch (e: Exception) {
+      uiFacade.showErrorDialog(e)
+    }
+  }
+
+  private fun doTryImportDocument(document: Document): Boolean {
     var success = false
     val importers = PluginManager.getExtensions(
       Importer.EXTENSION_POINT_ID,
@@ -528,6 +550,8 @@ internal class CommandLineProjectOpenStrategy(
         try {
           taskManager.setEventsEnabled(false)
           importer.setContext(project, uiFacade, preferences)
+          val wizardModel = ImporterWizardModel()
+          importer.setModel(wizardModel)
           importer.setFile(File(document.filePath))
           importer.run()
           success = true

--- a/ganttproject/src/main/java/net/sourceforge/ganttproject/gui/ProjectOpenStrategy.kt
+++ b/ganttproject/src/main/java/net/sourceforge/ganttproject/gui/ProjectOpenStrategy.kt
@@ -39,6 +39,8 @@ import net.sourceforge.ganttproject.action.GPAction
 import net.sourceforge.ganttproject.action.OkAction
 import net.sourceforge.ganttproject.document.Document
 import net.sourceforge.ganttproject.document.DocumentManager
+import net.sourceforge.ganttproject.gui.projectopen.DOCUMENT_ERROR_LOGGER
+import net.sourceforge.ganttproject.gui.projectopen.showProjectOpenErrorDialog
 import net.sourceforge.ganttproject.importer.Importer
 import net.sourceforge.ganttproject.importer.ImporterWizardModel
 import net.sourceforge.ganttproject.language.GanttLanguage
@@ -531,19 +533,7 @@ internal class CommandLineProjectOpenStrategy(
           project.documentManager.getProxyDocument(lastDocument), project, null
         )
         stateMachine.stateFailed.await { error ->
-          val msg = """
-            Failed to open project: {}
-            {}
-            -------
-            {}
-          """.trimIndent()
-          DOCUMENT_ERROR_LOGGER.error(msg, lastDocument.uri, error.errorTitle, error.errorDescription, exception = error.throwable)
-          val notification = uiFacade.notificationManager.createNotification(
-            NotificationChannel.ERROR, error.errorTitle, error.errorDescription, null
-          )
-          uiFacade.notificationManager.showDialog(
-            RootLocalizer.formatText("project.open.error.title"),
-            listOf(notification))
+          error.showProjectOpenErrorDialog(lastDocument, uiFacade.notificationManager)
         }
       }
     }

--- a/ganttproject/src/main/java/net/sourceforge/ganttproject/gui/ProjectUIFacade.kt
+++ b/ganttproject/src/main/java/net/sourceforge/ganttproject/gui/ProjectUIFacade.kt
@@ -20,7 +20,6 @@ package net.sourceforge.ganttproject.gui
 
 import biz.ganttproject.app.Barrier
 import biz.ganttproject.core.option.GPOptionGroup
-import kotlinx.coroutines.channels.Channel
 import net.sourceforge.ganttproject.IGanttProject
 import net.sourceforge.ganttproject.ProjectOpenActivityFactory
 import net.sourceforge.ganttproject.ProjectOpenStateMachine
@@ -35,7 +34,7 @@ interface ProjectUIFacade {
   fun ensureProjectSaved(project: IGanttProject): Barrier<Boolean>
 
   @Throws(IOException::class, Document.DocumentException::class)
-  fun openProject(document: Document, project: IGanttProject, onFinish: Channel<Boolean>?, authenticationFlow: AuthenticationFlow? = null): ProjectOpenStateMachine
+  fun openProject(document: Document, project: IGanttProject, authenticationFlow: AuthenticationFlow? = null): ProjectOpenStateMachine
   fun createProject(project: IGanttProject)
   fun getOptionGroups(): Array<GPOptionGroup>
 

--- a/ganttproject/src/main/java/net/sourceforge/ganttproject/gui/ProjectUIFacadeImpl.kt
+++ b/ganttproject/src/main/java/net/sourceforge/ganttproject/gui/ProjectUIFacadeImpl.kt
@@ -254,6 +254,7 @@ class ProjectUIFacadeImpl(
           }
 
           OpenOnlineDocumentChoice.CANCEL -> {
+            stateMachine.cancel()
           }
         }
       }
@@ -269,6 +270,7 @@ class ProjectUIFacadeImpl(
     stateMachine.transition(stateMachine.stateDocumentReady,ProjectOpenActivityMainModelReady.ID) {
       onDocumentReady(stateMachine.project, it.document, strategy)
       installColloboqueClient(stateMachine.project, it.document)
+      strategy.close()
       // --------------------------------
       ProjectOpenActivityMainModelReady()
     }

--- a/ganttproject/src/main/java/net/sourceforge/ganttproject/gui/ProjectUIFacadeImpl.kt
+++ b/ganttproject/src/main/java/net/sourceforge/ganttproject/gui/ProjectUIFacadeImpl.kt
@@ -36,6 +36,7 @@ import javafx.scene.layout.Pane
 import javafx.stage.Window
 import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.swing.Swing
 import net.sourceforge.ganttproject.*
 import net.sourceforge.ganttproject.action.CancelAction
 import net.sourceforge.ganttproject.action.OkAction
@@ -209,13 +210,73 @@ class ProjectUIFacadeImpl(
     return result
   }
 
+  private suspend fun installColloboqueClient(project: IGanttProject, doc: Document) {
+    doc.asOnlineDocument()?.let {
+      if (it is GPCloudDocument) {
+        it.colloboqueClient = ColloboqueClient(project.projectDatabase, undoManager)
+        project.projectDatabase.addExternalUpdatesListener {
+          Platform.runLater {
+            val emptyTaskManager = project.taskManager.emptyClone()
+            emptyTaskManager.importFromDatabase(project.projectDatabase.readAllTasks(), project.taskManager.taskHierarchy.export())
+            val bufferProject = BufferProject(
+              emptyTaskManager,
+              project.projectDatabase,
+              project.roleManager,
+              project.activeCalendar,
+              myWorkbenchFacade
+            )
+            val mergeOption = HumanResourceMerger.MergeResourcesOption()
+            val importCalendarOption = ImportCalendarOption()
+            mergeOption.setSelectedValue(MergeResourcesEnum.BY_ID)
+            importCalendarOption.loadPersistentValue(ImportCalendarOption.Values.REPLACE.name)
+            importBufferProject(
+              project,
+              bufferProject,
+              myWorkbenchFacade.asImportBufferProjectApi(),
+              mergeOption,
+              importCalendarOption,
+              closeCurrentProject = true
+            )
+          }
+        }
+        it.onboard(documentManager, webSocket)
+      }
+    }
+  }
+
+  private suspend fun onDocumentReady(project: IGanttProject, doc: Document, strategy: ProjectOpenStrategy) {
+    DOCUMENT_LOGGER.debug("... document is ready")
+    // If document is obtained, we need to run further steps.
+    // Because of historical reasons they run in Swing thread (they may modify the state of Swing components)
+    withContext(Dispatchers.Swing) {
+      project.close()
+      strategy.openFileAsIs(doc)
+        .checkLegacyMilestones()
+        .checkEarliestStartConstraints()
+        .runUiTasks()
+    }
+  }
 
   @Throws(IOException::class, DocumentException::class)
   override fun openProject(document: Document, project: IGanttProject, onFinish: Channel<Boolean>?,
                            authenticationFlow: AuthenticationFlow?): ProjectOpenStateMachine {
     val stateMachine = projectOpenActivityFactory.createStateMachine(project)
     try {
-      stateMachine.state = ProjectOpenActivityStarted()
+      val strategy = ProjectOpenStrategy(
+        project = project,
+        uiFacade = myWorkbenchFacade,
+        signin = authenticationFlow ?: this::signin,
+      )
+      stateMachine.transition(stateMachine.stateStarted, ProjectOpenActivityDocumentReady.ID) {
+          strategy.use {
+            ProjectOpenActivityDocumentReady(strategy.open(document))
+          }
+      }
+      stateMachine.transition(stateMachine.stateDocumentReady,ProjectOpenActivityMainModelReady.ID) {
+        onDocumentReady(project, it.document, strategy)
+        installColloboqueClient(project, it.document)
+        ProjectOpenActivityMainModelReady()
+      }
       stateMachine.stateCalculatedModelReady.await {
         stateMachine.state = ProjectOpenActivityCompleted()
       }
@@ -223,88 +284,35 @@ class ProjectUIFacadeImpl(
         undoManager.die()
       }
 
-      ProjectOpenStrategy(
-        project = project,
-        uiFacade = myWorkbenchFacade,
-        signin = authenticationFlow ?: this::signin,
-      ).use { strategy ->
-        DOCUMENT_LOGGER.debug(">>> openProject({})", document.uri)
-        // Run coroutine which fetches document and wait until it sends the result to the channel.
-        val docChannel = Channel<Document>()
-        CoroutineScope(Executors.newSingleThreadExecutor().asCoroutineDispatcher()).launch {
-          try {
-            DOCUMENT_LOGGER.debug("... waiting for the document")
-            docChannel.receive().also { doc ->
-              DOCUMENT_LOGGER.debug("... document is ready")
-              // If document is obtained, we need to run further steps.
-              // Because of historical reasons they run in Swing thread (they may modify the state of Swing components)
-              SwingUtilities.invokeLater {
-                try {
-                  project.close()
-                  strategy.openFileAsIs(doc)
-                    .checkLegacyMilestones()
-                    .checkEarliestStartConstraints()
-                    .runUiTasks()
-                  stateMachine.state = ProjectOpenActivityMainModelReady()
-                  document.asOnlineDocument()?.let {
-                    if (it is GPCloudDocument) {
-                      it.colloboqueClient = ColloboqueClient(project.projectDatabase, undoManager)
-                      project.projectDatabase.addExternalUpdatesListener {
-                        Platform.runLater {
-                          val emptyTaskManager = project.taskManager.emptyClone()
-                          emptyTaskManager.importFromDatabase(project.projectDatabase.readAllTasks(), project.taskManager.taskHierarchy.export())
-                          val bufferProject = BufferProject(
-                            emptyTaskManager,
-                            project.projectDatabase,
-                            project.roleManager,
-                            project.activeCalendar,
-                            myWorkbenchFacade
-                          )
-                          val mergeOption = HumanResourceMerger.MergeResourcesOption()
-                          val importCalendarOption = ImportCalendarOption()
-                          mergeOption.setSelectedValue(MergeResourcesEnum.BY_ID)
-                          importCalendarOption.loadPersistentValue(ImportCalendarOption.Values.REPLACE.name)
-                          importBufferProject(
-                            project,
-                            bufferProject,
-                            myWorkbenchFacade.asImportBufferProjectApi(),
-                            mergeOption,
-                            importCalendarOption,
-                            closeCurrentProject = true
-                          )
-                        }
-                      }
-                      it.onboard(documentManager, webSocket)
-                    }
-                  }
-                  runBlocking {
-                    onFinish?.send(true)
-                  }
-                } catch (ex: DocumentException) {
-                  ex.printStackTrace()
-                  stateMachine.fail(ex)
-                  onFinish?.close(ex) ?: DOCUMENT_ERROR_LOGGER.error("", ex)
-                }
-              }
-            }
-          } catch (ex: Exception) {
-            when (ex) {
-              // If channel was closed with a cause and it was because of HTTP 403, we show UI for sign-in
-              is DocumentException -> {
-                onFinish?.close(ex) ?: DOCUMENT_ERROR_LOGGER.error("", ex)
-              }
-              else -> {
-                onFinish?.close(ex) ?: DOCUMENT_ERROR_LOGGER.error("Can't open document $document", ex)
-              }
-            }
-            stateMachine.fail(ex)
-          }
-          finally {
-            DOCUMENT_LOGGER.debug("<<< openProject()")
-          }
-        }
-        strategy.open(document, docChannel)
-      }
+      stateMachine.state = ProjectOpenActivityStarted()
+
+//      strategy.use { strategy ->
+//        DOCUMENT_LOGGER.debug(">>> openProject({})", document.uri)
+//        // Run coroutine which fetches document and wait until it sends the result to the channel.
+//        val docChannel = Channel<Document>()
+//        CoroutineScope(Executors.newSingleThreadExecutor().asCoroutineDispatcher()).launch {
+//          try {
+//            DOCUMENT_LOGGER.debug("... waiting for the document")
+//            docChannel.receive().also { doc ->
+//            }
+//          } catch (ex: Exception) {
+//            when (ex) {
+//              // If channel was closed with a cause and it was because of HTTP 403, we show UI for sign-in
+//              is DocumentException -> {
+//                onFinish?.close(ex) ?: DOCUMENT_ERROR_LOGGER.error("", ex)
+//              }
+//              else -> {
+//                onFinish?.close(ex) ?: DOCUMENT_ERROR_LOGGER.error("Can't open document $document", ex)
+//              }
+//            }
+//            stateMachine.fail(ex)
+//          }
+//          finally {
+//            DOCUMENT_LOGGER.debug("<<< openProject()")
+//          }
+//        }
+//        strategy.open(document, docChannel)
+//      }
     } catch (e: Exception) {
       throw DocumentException("Can't open document $document", e)
     }

--- a/ganttproject/src/main/java/net/sourceforge/ganttproject/gui/ProjectUIFacadeImpl.kt
+++ b/ganttproject/src/main/java/net/sourceforge/ganttproject/gui/ProjectUIFacadeImpl.kt
@@ -248,7 +248,7 @@ class ProjectUIFacadeImpl(
       installColloboqueClient(stateMachine.project, it.document)
       strategy.close()
       // --------------------------------
-      ProjectOpenActivityMainModelReady()
+      ProjectOpenActivityMainModelReady(it.document)
     }
     stateMachine.stateCalculatedModelReady.await {
       stateMachine.state = ProjectOpenActivityCompleted()

--- a/ganttproject/src/main/java/net/sourceforge/ganttproject/gui/ProjectUIFacadeImpl.kt
+++ b/ganttproject/src/main/java/net/sourceforge/ganttproject/gui/ProjectUIFacadeImpl.kt
@@ -45,6 +45,9 @@ import net.sourceforge.ganttproject.document.Document.DocumentException
 import net.sourceforge.ganttproject.document.DocumentManager
 import net.sourceforge.ganttproject.document.ProxyDocument
 import net.sourceforge.ganttproject.document.webdav.WebDavStorageImpl
+import net.sourceforge.ganttproject.gui.projectopen.OpenOnlineDocumentChoice
+import net.sourceforge.ganttproject.gui.projectopen.showForkDialog
+import net.sourceforge.ganttproject.gui.projectopen.showOfflineIsAheadDialog
 import net.sourceforge.ganttproject.gui.projectwizard.createNewProject
 import net.sourceforge.ganttproject.importer.BufferProject
 import net.sourceforge.ganttproject.importer.asImportBufferProjectApi
@@ -262,6 +265,7 @@ class ProjectUIFacadeImpl(
                            authenticationFlow: AuthenticationFlow?): ProjectOpenStateMachine {
     val stateMachine = projectOpenActivityFactory.createStateMachine(project)
     try {
+      val authFlow = authenticationFlow ?: this::signin
       val strategy = ProjectOpenStrategy(
         project = project,
         uiFacade = myWorkbenchFacade,
@@ -271,14 +275,42 @@ class ProjectUIFacadeImpl(
       stateMachine.stateStarted.await {
         strategy.start(document)
       }
-//      stateMachine.transition(stateMachine.stateStarted, ProjectOpenActivityDocumentReady.ID) {
-//          strategy.use {
-//            ProjectOpenActivityDocumentReady(strategy.open(document))
-//          }
-//      }
+      stateMachine.stateAuthRequired.await {
+        authFlow {
+          if (stateMachine.state is ProjectOpenActivityAuthRequired) {
+            stateMachine.state = ProjectOpenActivityStarted()
+          }
+        }
+      }
+      stateMachine.stateDocumentForked.await { forkedDocument ->
+        fun handleChoice(choice: OpenOnlineDocumentChoice) {
+          when (choice) {
+            OpenOnlineDocumentChoice.USE_OFFLINE -> {
+              forkedDocument.fetchResult.useMirror = true
+              stateMachine.state = ProjectOpenActivityDocumentReady(forkedDocument.document)
+            }
+
+            OpenOnlineDocumentChoice.USE_ONLINE -> {
+              stateMachine.state = ProjectOpenActivityDocumentReady(forkedDocument.document)
+            }
+
+            OpenOnlineDocumentChoice.CANCEL -> {
+            }
+          }
+        }
+        when (forkedDocument.forkCase) {
+          ProjectOpenActivityDocumentForked.ForkCase.OFFLINE_AHEAD -> {
+            showOfflineIsAheadDialog(::handleChoice)
+          }
+          ProjectOpenActivityDocumentForked.ForkCase.FORK -> {
+            showForkDialog(::handleChoice)
+          }
+        }
+      }
       stateMachine.transition(stateMachine.stateDocumentReady,ProjectOpenActivityMainModelReady.ID) {
         onDocumentReady(project, it.document, strategy)
         installColloboqueClient(project, it.document)
+        // --------------------------------
         ProjectOpenActivityMainModelReady()
       }
       stateMachine.stateCalculatedModelReady.await {

--- a/ganttproject/src/main/java/net/sourceforge/ganttproject/gui/ProjectUIFacadeImpl.kt
+++ b/ganttproject/src/main/java/net/sourceforge/ganttproject/gui/ProjectUIFacadeImpl.kt
@@ -226,7 +226,7 @@ class ProjectUIFacadeImpl(
           }
 
           OpenOnlineDocumentChoice.CANCEL -> {
-            stateMachine.state = ProjectOpenActivityCompleted(stateMachine.project, forkedDocument.document)
+            stateMachine.state = ProjectOpenActivityCancelled(stateMachine.project, forkedDocument.document)
           }
         }
       }
@@ -256,6 +256,10 @@ class ProjectUIFacadeImpl(
     stateMachine.stateCompleted.await {
       undoManager.die()
     }
+    stateMachine.stateCancelled.await {
+      // The user cancelled the opening process, so the previously open project remains intact.
+      // We keep the undo history of that project, hence no undoManager.die() here.
+    }
   }
 
   fun installAuthFlow(sm: ProjectOpenStateMachine, authFlow: AuthenticationFlow) {
@@ -275,34 +279,6 @@ class ProjectUIFacadeImpl(
     try {
       installAuthFlow(stateMachine, authenticationFlow ?: ::signinDialog)
       stateMachine.start(document)
-
-//      strategy.use { strategy ->
-//        DOCUMENT_LOGGER.debug(">>> openProject({})", document.uri)
-//        // Run coroutine which fetches document and wait until it sends the result to the channel.
-//        val docChannel = Channel<Document>()
-//        CoroutineScope(Executors.newSingleThreadExecutor().asCoroutineDispatcher()).launch {
-//          try {
-//            DOCUMENT_LOGGER.debug("... waiting for the document")
-//            docChannel.receive().also { doc ->
-//            }
-//          } catch (ex: Exception) {
-//            when (ex) {
-//              // If channel was closed with a cause and it was because of HTTP 403, we show UI for sign-in
-//              is DocumentException -> {
-//                onFinish?.close(ex) ?: DOCUMENT_ERROR_LOGGER.error("", ex)
-//              }
-//              else -> {
-//                onFinish?.close(ex) ?: DOCUMENT_ERROR_LOGGER.error("Can't open document $document", ex)
-//              }
-//            }
-//            stateMachine.fail(ex)
-//          }
-//          finally {
-//            DOCUMENT_LOGGER.debug("<<< openProject()")
-//          }
-//        }
-//        strategy.open(document, docChannel)
-//      }
     } catch (e: Exception) {
       throw DocumentException("Can't open document $document", e)
     }

--- a/ganttproject/src/main/java/net/sourceforge/ganttproject/gui/ProjectUIFacadeImpl.kt
+++ b/ganttproject/src/main/java/net/sourceforge/ganttproject/gui/ProjectUIFacadeImpl.kt
@@ -266,12 +266,16 @@ class ProjectUIFacadeImpl(
         project = project,
         uiFacade = myWorkbenchFacade,
         signin = authenticationFlow ?: this::signin,
+        stateMachine = stateMachine
       )
-      stateMachine.transition(stateMachine.stateStarted, ProjectOpenActivityDocumentReady.ID) {
-          strategy.use {
-            ProjectOpenActivityDocumentReady(strategy.open(document))
-          }
+      stateMachine.stateStarted.await {
+        strategy.start(document)
       }
+//      stateMachine.transition(stateMachine.stateStarted, ProjectOpenActivityDocumentReady.ID) {
+//          strategy.use {
+//            ProjectOpenActivityDocumentReady(strategy.open(document))
+//          }
+//      }
       stateMachine.transition(stateMachine.stateDocumentReady,ProjectOpenActivityMainModelReady.ID) {
         onDocumentReady(project, it.document, strategy)
         installColloboqueClient(project, it.document)

--- a/ganttproject/src/main/java/net/sourceforge/ganttproject/gui/ProjectUIFacadeImpl.kt
+++ b/ganttproject/src/main/java/net/sourceforge/ganttproject/gui/ProjectUIFacadeImpl.kt
@@ -24,16 +24,19 @@ import biz.ganttproject.core.calendar.ImportCalendarOption
 import biz.ganttproject.core.option.GPOptionGroup
 import biz.ganttproject.lib.fx.VBoxBuilder
 import biz.ganttproject.storage.*
-import biz.ganttproject.storage.cloud.*
+import biz.ganttproject.storage.cloud.GPCloudDocument
+import biz.ganttproject.storage.cloud.installColloboque
+import biz.ganttproject.storage.cloud.onboard
+import biz.ganttproject.storage.cloud.webSocket
 import com.google.common.collect.Lists
 import com.sandec.mdfx.MDFXNode
 import de.jensd.fx.glyphs.fontawesome.FontAwesomeIcon
 import de.jensd.fx.glyphs.fontawesome.FontAwesomeIconView
-import javafx.application.Platform
 import javafx.geometry.Pos
 import javafx.stage.Window
-import kotlinx.coroutines.*
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.swing.Swing
+import kotlinx.coroutines.withContext
 import net.sourceforge.ganttproject.*
 import net.sourceforge.ganttproject.action.CancelAction
 import net.sourceforge.ganttproject.action.OkAction
@@ -43,18 +46,11 @@ import net.sourceforge.ganttproject.document.DocumentManager
 import net.sourceforge.ganttproject.document.ProxyDocument
 import net.sourceforge.ganttproject.document.webdav.WebDavStorageImpl
 import net.sourceforge.ganttproject.gui.projectopen.OpenOnlineDocumentChoice
-import net.sourceforge.ganttproject.gui.projectopen.signinDialog
 import net.sourceforge.ganttproject.gui.projectopen.showForkDialog
 import net.sourceforge.ganttproject.gui.projectopen.showOfflineIsAheadDialog
+import net.sourceforge.ganttproject.gui.projectopen.signinDialog
 import net.sourceforge.ganttproject.gui.projectwizard.createNewProject
-import net.sourceforge.ganttproject.importer.BufferProject
-import net.sourceforge.ganttproject.importer.asImportBufferProjectApi
-import net.sourceforge.ganttproject.importer.importBufferProject
 import net.sourceforge.ganttproject.language.GanttLanguage
-import net.sourceforge.ganttproject.resource.HumanResourceMerger
-import net.sourceforge.ganttproject.resource.MergeResourcesEnum
-import net.sourceforge.ganttproject.task.export
-import net.sourceforge.ganttproject.task.importFromDatabase
 import net.sourceforge.ganttproject.undo.GPUndoManager
 import java.io.File
 import java.io.IOException
@@ -187,32 +183,7 @@ class ProjectUIFacadeImpl(
   private suspend fun installColloboqueClient(project: IGanttProject, doc: Document) {
     doc.asOnlineDocument()?.let {
       if (it is GPCloudDocument) {
-        it.colloboqueClient = ColloboqueClient(project.projectDatabase, undoManager)
-        project.projectDatabase.addExternalUpdatesListener {
-          Platform.runLater {
-            val emptyTaskManager = project.taskManager.emptyClone()
-            emptyTaskManager.importFromDatabase(project.projectDatabase.readAllTasks(), project.taskManager.taskHierarchy.export())
-            val bufferProject = BufferProject(
-              emptyTaskManager,
-              project.projectDatabase,
-              project.roleManager,
-              project.activeCalendar,
-              myWorkbenchFacade
-            )
-            val mergeOption = HumanResourceMerger.MergeResourcesOption()
-            val importCalendarOption = ImportCalendarOption()
-            mergeOption.setSelectedValue(MergeResourcesEnum.BY_ID)
-            importCalendarOption.loadPersistentValue(ImportCalendarOption.Values.REPLACE.name)
-            importBufferProject(
-              project,
-              bufferProject,
-              myWorkbenchFacade.asImportBufferProjectApi(),
-              mergeOption,
-              importCalendarOption,
-              closeCurrentProject = true
-            )
-          }
-        }
+        installColloboque(it, project, undoManager, myWorkbenchFacade)
         it.onboard(documentManager, webSocket)
       }
     }
@@ -231,6 +202,7 @@ class ProjectUIFacadeImpl(
     }
   }
 
+  private var cnt = 0
   private fun initStateMachine(stateMachine: ProjectOpenStateMachine) {
     val strategy = ProjectOpenStrategy(
       project = stateMachine.project,
@@ -268,6 +240,11 @@ class ProjectUIFacadeImpl(
       }
     }
     stateMachine.transition(stateMachine.stateDocumentReady,ProjectOpenActivityMainModelReady.ID) {
+
+      //      if (cnt > 1) {
+//        return@transition ProjectOpenActivityFailed("Test Failure", "Failure when fetching", RuntimeException("Foo"))
+//      }
+//      cnt++
       onDocumentReady(stateMachine.project, it.document, strategy)
       installColloboqueClient(stateMachine.project, it.document)
       strategy.close()
@@ -502,4 +479,4 @@ class ProjectSaveFlow(
 }
 
 private val DOCUMENT_LOGGER = GPLogger.create("Document.Info")
-private val DOCUMENT_ERROR_LOGGER = GPLogger.create("Document.Error")
+val DOCUMENT_ERROR_LOGGER = GPLogger.create("Document.Error")

--- a/ganttproject/src/main/java/net/sourceforge/ganttproject/gui/ProjectUIFacadeImpl.kt
+++ b/ganttproject/src/main/java/net/sourceforge/ganttproject/gui/ProjectUIFacadeImpl.kt
@@ -35,7 +35,6 @@ import javafx.scene.layout.BorderPane
 import javafx.scene.layout.Pane
 import javafx.stage.Window
 import kotlinx.coroutines.*
-import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.swing.Swing
 import net.sourceforge.ganttproject.*
 import net.sourceforge.ganttproject.action.CancelAction
@@ -60,7 +59,6 @@ import net.sourceforge.ganttproject.task.importFromDatabase
 import net.sourceforge.ganttproject.undo.GPUndoManager
 import java.io.File
 import java.io.IOException
-import java.util.concurrent.Executors
 import java.util.logging.Level
 import javax.swing.JOptionPane
 import javax.swing.SwingUtilities
@@ -78,7 +76,7 @@ class ProjectUIFacadeImpl(
   private val myConverterGroup = GPOptionGroup("convert", ProjectOpenStrategy.milestonesOption)
   private var isSaving = false
 
-  override val projectOpenActivityFactory = ProjectOpenActivityFactory()
+  override val projectOpenActivityFactory = ProjectOpenActivityFactory
 
   override fun saveProject(project: IGanttProject): Barrier<Boolean> {
     if (isSaving) {
@@ -261,7 +259,7 @@ class ProjectUIFacadeImpl(
   }
 
   @Throws(IOException::class, DocumentException::class)
-  override fun openProject(document: Document, project: IGanttProject, onFinish: Channel<Boolean>?,
+  override fun openProject(document: Document, project: IGanttProject,
                            authenticationFlow: AuthenticationFlow?): ProjectOpenStateMachine {
     val stateMachine = projectOpenActivityFactory.createStateMachine(project)
     try {

--- a/ganttproject/src/main/java/net/sourceforge/ganttproject/gui/ProjectUIFacadeImpl.kt
+++ b/ganttproject/src/main/java/net/sourceforge/ganttproject/gui/ProjectUIFacadeImpl.kt
@@ -240,8 +240,7 @@ class ProjectUIFacadeImpl(
       }
     }
     stateMachine.transition(stateMachine.stateDocumentReady,ProjectOpenActivityMainModelReady.ID) {
-
-      //      if (cnt > 1) {
+//      if (cnt > 1) {
 //        return@transition ProjectOpenActivityFailed("Test Failure", "Failure when fetching", RuntimeException("Foo"))
 //      }
 //      cnt++
@@ -479,4 +478,3 @@ class ProjectSaveFlow(
 }
 
 private val DOCUMENT_LOGGER = GPLogger.create("Document.Info")
-val DOCUMENT_ERROR_LOGGER = GPLogger.create("Document.Error")

--- a/ganttproject/src/main/java/net/sourceforge/ganttproject/gui/ProjectUIFacadeImpl.kt
+++ b/ganttproject/src/main/java/net/sourceforge/ganttproject/gui/ProjectUIFacadeImpl.kt
@@ -31,8 +31,6 @@ import de.jensd.fx.glyphs.fontawesome.FontAwesomeIcon
 import de.jensd.fx.glyphs.fontawesome.FontAwesomeIconView
 import javafx.application.Platform
 import javafx.geometry.Pos
-import javafx.scene.layout.BorderPane
-import javafx.scene.layout.Pane
 import javafx.stage.Window
 import kotlinx.coroutines.*
 import kotlinx.coroutines.swing.Swing
@@ -45,6 +43,7 @@ import net.sourceforge.ganttproject.document.DocumentManager
 import net.sourceforge.ganttproject.document.ProxyDocument
 import net.sourceforge.ganttproject.document.webdav.WebDavStorageImpl
 import net.sourceforge.ganttproject.gui.projectopen.OpenOnlineDocumentChoice
+import net.sourceforge.ganttproject.gui.projectopen.signinDialog
 import net.sourceforge.ganttproject.gui.projectopen.showForkDialog
 import net.sourceforge.ganttproject.gui.projectopen.showOfflineIsAheadDialog
 import net.sourceforge.ganttproject.gui.projectwizard.createNewProject
@@ -78,6 +77,9 @@ class ProjectUIFacadeImpl(
 
   override val projectOpenActivityFactory = ProjectOpenActivityFactory
 
+  init {
+    projectOpenActivityFactory.addBuilder(this::initStateMachine)
+  }
   override fun saveProject(project: IGanttProject): Barrier<Boolean> {
     if (isSaving) {
       GPLogger.logToLogger("We're saving the project now. This save request was rejected")
@@ -89,7 +91,7 @@ class ProjectUIFacadeImpl(
         afterSaveProject(project)
       }
       ProjectSaveFlow(project = project, onFinish = saveBarrier,
-        signin = this::signin,
+        signin = ::signinDialog,
         error = this::onError,
         saveAs = { saveProjectAs(project) }
       ).run()
@@ -132,35 +134,6 @@ class ProjectUIFacadeImpl(
 
   enum class CantWriteChoice {MAKE_COPY, CANCEL, RETRY}
 
-  private fun signin(onAuth: ()->Unit) {
-    dialog { controller ->
-      val wrapper = BorderPane()
-      controller.addStyleClass("dlg-lock", "dlg-cloud-file-options")
-      controller.addStyleSheet(
-        "/biz/ganttproject/storage/cloud/GPCloudStorage.css",
-        "/biz/ganttproject/storage/StorageDialog.css"
-      )
-      wrapper.center = Pane().also {
-        it.prefHeight = 400.0
-        it.prefWidth = 400.0
-      }
-      controller.setContent(wrapper)
-      GPCloudUiFlowBuilder().apply {
-        flowPageChanger = createFlowPageChanger(wrapper, controller)
-        mainPage = object : EmptyFlowPage() {
-          override var active: Boolean
-            get() = super.active
-            set(value) {
-              if (value) {
-                controller.hide()
-                onAuth()
-              }
-            }
-        }
-        build().start()
-      }
-    }
-  }
 //  private fun formatWriteStatusMessage(doc: Document, canWrite: IStatus): String {
 //    assert(canWrite.code >= 0 && canWrite.code < Document.ErrorCode.values().size)
 //    return RootLocalizer.formatText(
@@ -258,67 +231,72 @@ class ProjectUIFacadeImpl(
     }
   }
 
+  private fun initStateMachine(stateMachine: ProjectOpenStateMachine) {
+    val strategy = ProjectOpenStrategy(
+      project = stateMachine.project,
+      uiFacade = myWorkbenchFacade,
+      signin = ::signinDialog,
+      stateMachine = stateMachine
+    )
+    stateMachine.stateStarted.await {
+      strategy.start(it.document)
+    }
+    stateMachine.stateDocumentForked.await { forkedDocument ->
+      fun handleChoice(choice: OpenOnlineDocumentChoice) {
+        when (choice) {
+          OpenOnlineDocumentChoice.USE_OFFLINE -> {
+            forkedDocument.fetchResult.useMirror = true
+            stateMachine.state = ProjectOpenActivityDocumentReady(forkedDocument.document)
+          }
+
+          OpenOnlineDocumentChoice.USE_ONLINE -> {
+            stateMachine.state = ProjectOpenActivityDocumentReady(forkedDocument.document)
+          }
+
+          OpenOnlineDocumentChoice.CANCEL -> {
+          }
+        }
+      }
+      when (forkedDocument.forkCase) {
+        ProjectOpenActivityDocumentForked.ForkCase.OFFLINE_AHEAD -> {
+          showOfflineIsAheadDialog(::handleChoice)
+        }
+        ProjectOpenActivityDocumentForked.ForkCase.FORK -> {
+          showForkDialog(::handleChoice)
+        }
+      }
+    }
+    stateMachine.transition(stateMachine.stateDocumentReady,ProjectOpenActivityMainModelReady.ID) {
+      onDocumentReady(stateMachine.project, it.document, strategy)
+      installColloboqueClient(stateMachine.project, it.document)
+      // --------------------------------
+      ProjectOpenActivityMainModelReady()
+    }
+    stateMachine.stateCalculatedModelReady.await {
+      stateMachine.state = ProjectOpenActivityCompleted()
+    }
+    stateMachine.stateCompleted.await {
+      undoManager.die()
+    }
+  }
+
+  fun installAuthFlow(sm: ProjectOpenStateMachine, authFlow: AuthenticationFlow) {
+    sm.stateAuthRequired.await { state ->
+      authFlow {
+        if (sm.state is ProjectOpenActivityAuthRequired) {
+          sm.state = ProjectOpenActivityStarted(state.document)
+        }
+      }
+    }
+  }
+
   @Throws(IOException::class, DocumentException::class)
   override fun openProject(document: Document, project: IGanttProject,
                            authenticationFlow: AuthenticationFlow?): ProjectOpenStateMachine {
     val stateMachine = projectOpenActivityFactory.createStateMachine(project)
     try {
-      val authFlow = authenticationFlow ?: this::signin
-      val strategy = ProjectOpenStrategy(
-        project = project,
-        uiFacade = myWorkbenchFacade,
-        signin = authenticationFlow ?: this::signin,
-        stateMachine = stateMachine
-      )
-      stateMachine.stateStarted.await {
-        strategy.start(document)
-      }
-      stateMachine.stateAuthRequired.await {
-        authFlow {
-          if (stateMachine.state is ProjectOpenActivityAuthRequired) {
-            stateMachine.state = ProjectOpenActivityStarted()
-          }
-        }
-      }
-      stateMachine.stateDocumentForked.await { forkedDocument ->
-        fun handleChoice(choice: OpenOnlineDocumentChoice) {
-          when (choice) {
-            OpenOnlineDocumentChoice.USE_OFFLINE -> {
-              forkedDocument.fetchResult.useMirror = true
-              stateMachine.state = ProjectOpenActivityDocumentReady(forkedDocument.document)
-            }
-
-            OpenOnlineDocumentChoice.USE_ONLINE -> {
-              stateMachine.state = ProjectOpenActivityDocumentReady(forkedDocument.document)
-            }
-
-            OpenOnlineDocumentChoice.CANCEL -> {
-            }
-          }
-        }
-        when (forkedDocument.forkCase) {
-          ProjectOpenActivityDocumentForked.ForkCase.OFFLINE_AHEAD -> {
-            showOfflineIsAheadDialog(::handleChoice)
-          }
-          ProjectOpenActivityDocumentForked.ForkCase.FORK -> {
-            showForkDialog(::handleChoice)
-          }
-        }
-      }
-      stateMachine.transition(stateMachine.stateDocumentReady,ProjectOpenActivityMainModelReady.ID) {
-        onDocumentReady(project, it.document, strategy)
-        installColloboqueClient(project, it.document)
-        // --------------------------------
-        ProjectOpenActivityMainModelReady()
-      }
-      stateMachine.stateCalculatedModelReady.await {
-        stateMachine.state = ProjectOpenActivityCompleted()
-      }
-      stateMachine.stateCompleted.await {
-        undoManager.die()
-      }
-
-      stateMachine.state = ProjectOpenActivityStarted()
+      installAuthFlow(stateMachine, authenticationFlow ?: ::signinDialog)
+      stateMachine.start(document)
 
 //      strategy.use { strategy ->
 //        DOCUMENT_LOGGER.debug(">>> openProject({})", document.uri)

--- a/ganttproject/src/main/java/net/sourceforge/ganttproject/gui/ProjectUIFacadeImpl.kt
+++ b/ganttproject/src/main/java/net/sourceforge/ganttproject/gui/ProjectUIFacadeImpl.kt
@@ -226,7 +226,7 @@ class ProjectUIFacadeImpl(
           }
 
           OpenOnlineDocumentChoice.CANCEL -> {
-            stateMachine.cancel()
+            stateMachine.state = ProjectOpenActivityCompleted(stateMachine.project, forkedDocument.document)
           }
         }
       }
@@ -251,7 +251,7 @@ class ProjectUIFacadeImpl(
       ProjectOpenActivityMainModelReady(it.document)
     }
     stateMachine.stateCalculatedModelReady.await {
-      stateMachine.state = ProjectOpenActivityCompleted()
+      stateMachine.state = ProjectOpenActivityCompleted(it.project, it.document)
     }
     stateMachine.stateCompleted.await {
       undoManager.die()

--- a/ganttproject/src/main/java/net/sourceforge/ganttproject/gui/projectopen/Authentication.kt
+++ b/ganttproject/src/main/java/net/sourceforge/ganttproject/gui/projectopen/Authentication.kt
@@ -1,0 +1,60 @@
+/*
+Copyright 2026 Dmitry Barashev,  BarD Software s.r.o
+
+This file is part of GanttProject, an open-source project management tool.
+
+GanttProject is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+GanttProject is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with GanttProject.  If not, see <http://www.gnu.org/licenses/>.
+*/
+package net.sourceforge.ganttproject.gui.projectopen
+
+import biz.ganttproject.app.dialog
+import biz.ganttproject.storage.cloud.EmptyFlowPage
+import biz.ganttproject.storage.cloud.GPCloudUiFlowBuilder
+import biz.ganttproject.storage.cloud.createFlowPageChanger
+import javafx.scene.layout.BorderPane
+import javafx.scene.layout.Pane
+
+/**
+ * Shows a dialog with authentication options for cloud storage.
+ * In case of successful authentication, calls the provided callback.
+ */
+fun signinDialog(onAuth: ()->Unit) {
+  dialog { controller ->
+    val wrapper = BorderPane()
+    controller.addStyleClass("dlg-lock", "dlg-cloud-file-options")
+    controller.addStyleSheet(
+      "/biz/ganttproject/storage/cloud/GPCloudStorage.css",
+      "/biz/ganttproject/storage/StorageDialog.css"
+    )
+    wrapper.center = Pane().also {
+      it.prefHeight = 400.0
+      it.prefWidth = 400.0
+    }
+    controller.setContent(wrapper)
+    GPCloudUiFlowBuilder().apply {
+      flowPageChanger = createFlowPageChanger(wrapper, controller)
+      mainPage = object : EmptyFlowPage() {
+        override var active: Boolean
+          get() = super.active
+          set(value) {
+            if (value) {
+              controller.hide()
+              onAuth()
+            }
+          }
+      }
+      build().start()
+    }
+  }
+}

--- a/ganttproject/src/main/java/net/sourceforge/ganttproject/gui/projectopen/DocumentForkDialog.kt
+++ b/ganttproject/src/main/java/net/sourceforge/ganttproject/gui/projectopen/DocumentForkDialog.kt
@@ -29,33 +29,27 @@ enum class OpenOnlineDocumentChoice { USE_OFFLINE, USE_ONLINE, CANCEL }
 fun showOfflineIsAheadDialog(handleChoice: (OpenOnlineDocumentChoice) -> Unit) {
   OptionPaneBuilder<OpenOnlineDocumentChoice>().run {
     i18n = RootLocalizer.createWithRootKey(rootKey = "cloud.openWhenOfflineIsAhead")
-    styleClass = "dlg-lock"
-    styleSheets.add("/biz/ganttproject/storage/cloud/GPCloudStorage.css")
-    styleSheets.add("/biz/ganttproject/storage/StorageDialog.css")
-    graphic = FontAwesomeIconView(FontAwesomeIcon.UNLOCK)
-    elements = listOf(
-      OptionElementData("useOffline", OpenOnlineDocumentChoice.USE_OFFLINE, true),
-      OptionElementData("useOnline", OpenOnlineDocumentChoice.USE_ONLINE),
-      OptionElementData("cancel", OpenOnlineDocumentChoice.CANCEL)
-    )
-
-    showDialog(handleChoice)
+    buildDialog(handleChoice)
   }
 }
 
 fun showForkDialog(handleChoice: (OpenOnlineDocumentChoice) -> Unit) {
   OptionPaneBuilder<OpenOnlineDocumentChoice>().run {
     i18n = RootLocalizer.createWithRootKey(rootKey = "cloud.openWhenDiverged")
-    styleClass = "dlg-lock"
-    styleSheets.add("/biz/ganttproject/storage/cloud/GPCloudStorage.css")
-    styleSheets.add("/biz/ganttproject/storage/StorageDialog.css")
-    graphic = FontAwesomeIconView(FontAwesomeIcon.UNLOCK)
-    elements = listOf(
-      OptionElementData("useOffline", OpenOnlineDocumentChoice.USE_OFFLINE, true),
-      OptionElementData("useOnline", OpenOnlineDocumentChoice.USE_ONLINE),
-      OptionElementData("cancel", OpenOnlineDocumentChoice.CANCEL)
-    )
-
-    showDialog(handleChoice)
+    buildDialog(handleChoice)
   }
+}
+
+private fun OptionPaneBuilder<OpenOnlineDocumentChoice>.buildDialog(handleChoice: (OpenOnlineDocumentChoice) -> Unit) {
+  styleClass = "dlg-lock"
+  styleSheets.add("/biz/ganttproject/storage/cloud/GPCloudStorage.css")
+  styleSheets.add("/biz/ganttproject/storage/StorageDialog.css")
+  graphic = FontAwesomeIconView(FontAwesomeIcon.CODE_FORK, "64")
+  elements = listOf(
+    OptionElementData("useOffline", OpenOnlineDocumentChoice.USE_OFFLINE, true),
+    OptionElementData("useOnline", OpenOnlineDocumentChoice.USE_ONLINE),
+    OptionElementData("cancel", OpenOnlineDocumentChoice.CANCEL)
+  )
+
+  showDialog(handleChoice)
 }

--- a/ganttproject/src/main/java/net/sourceforge/ganttproject/gui/projectopen/DocumentForkDialog.kt
+++ b/ganttproject/src/main/java/net/sourceforge/ganttproject/gui/projectopen/DocumentForkDialog.kt
@@ -1,0 +1,61 @@
+/*
+Copyright 2026 Dmitry Barashev,  BarD Software s.r.o
+
+This file is part of GanttProject, an open-source project management tool.
+
+GanttProject is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+GanttProject is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with GanttProject.  If not, see <http://www.gnu.org/licenses/>.
+*/
+package net.sourceforge.ganttproject.gui.projectopen
+
+import biz.ganttproject.app.OptionElementData
+import biz.ganttproject.app.OptionPaneBuilder
+import biz.ganttproject.app.RootLocalizer
+import de.jensd.fx.glyphs.fontawesome.FontAwesomeIcon
+import de.jensd.fx.glyphs.fontawesome.FontAwesomeIconView
+
+enum class OpenOnlineDocumentChoice { USE_OFFLINE, USE_ONLINE, CANCEL }
+
+fun showOfflineIsAheadDialog(handleChoice: (OpenOnlineDocumentChoice) -> Unit) {
+  OptionPaneBuilder<OpenOnlineDocumentChoice>().run {
+    i18n = RootLocalizer.createWithRootKey(rootKey = "cloud.openWhenOfflineIsAhead")
+    styleClass = "dlg-lock"
+    styleSheets.add("/biz/ganttproject/storage/cloud/GPCloudStorage.css")
+    styleSheets.add("/biz/ganttproject/storage/StorageDialog.css")
+    graphic = FontAwesomeIconView(FontAwesomeIcon.UNLOCK)
+    elements = listOf(
+      OptionElementData("useOffline", OpenOnlineDocumentChoice.USE_OFFLINE, true),
+      OptionElementData("useOnline", OpenOnlineDocumentChoice.USE_ONLINE),
+      OptionElementData("cancel", OpenOnlineDocumentChoice.CANCEL)
+    )
+
+    showDialog(handleChoice)
+  }
+}
+
+fun showForkDialog(handleChoice: (OpenOnlineDocumentChoice) -> Unit) {
+  OptionPaneBuilder<OpenOnlineDocumentChoice>().run {
+    i18n = RootLocalizer.createWithRootKey(rootKey = "cloud.openWhenDiverged")
+    styleClass = "dlg-lock"
+    styleSheets.add("/biz/ganttproject/storage/cloud/GPCloudStorage.css")
+    styleSheets.add("/biz/ganttproject/storage/StorageDialog.css")
+    graphic = FontAwesomeIconView(FontAwesomeIcon.UNLOCK)
+    elements = listOf(
+      OptionElementData("useOffline", OpenOnlineDocumentChoice.USE_OFFLINE, true),
+      OptionElementData("useOnline", OpenOnlineDocumentChoice.USE_ONLINE),
+      OptionElementData("cancel", OpenOnlineDocumentChoice.CANCEL)
+    )
+
+    showDialog(handleChoice)
+  }
+}

--- a/ganttproject/src/main/java/net/sourceforge/ganttproject/gui/projectopen/ErrorHandling.kt
+++ b/ganttproject/src/main/java/net/sourceforge/ganttproject/gui/projectopen/ErrorHandling.kt
@@ -1,0 +1,26 @@
+package net.sourceforge.ganttproject.gui.projectopen
+
+import biz.ganttproject.app.RootLocalizer
+import net.sourceforge.ganttproject.GPLogger
+import net.sourceforge.ganttproject.ProjectOpenActivityFailed
+import net.sourceforge.ganttproject.document.Document
+import net.sourceforge.ganttproject.gui.NotificationChannel
+import net.sourceforge.ganttproject.gui.NotificationManager
+
+fun ProjectOpenActivityFailed.showProjectOpenErrorDialog(document: Document, notificationManager: NotificationManager) {
+  val msg = """
+            Failed to open project: {}
+            {}
+            -------
+            {}
+          """.trimIndent()
+  DOCUMENT_ERROR_LOGGER.error(msg, document.uri, this.errorTitle, this.errorDescription, exception = this.throwable)
+  val notification = notificationManager.createNotification(
+    NotificationChannel.ERROR, this.errorTitle, this.errorDescription, null
+  )
+  notificationManager.showDialog(
+    RootLocalizer.formatText("project.open.error.title"),
+    listOf(notification))
+}
+
+val DOCUMENT_ERROR_LOGGER = GPLogger.create("Document.Error")

--- a/ganttproject/src/main/java/net/sourceforge/ganttproject/importer/BufferProject.java
+++ b/ganttproject/src/main/java/net/sourceforge/ganttproject/importer/BufferProject.java
@@ -47,7 +47,7 @@ import net.sourceforge.ganttproject.task.TaskManagerImpl;
 public class BufferProject extends GanttProjectImpl implements ParserFactory {
   PrjInfos myProjectInfo = new PrjInfos();
   final DocumentManager myDocumentManager;
-  final UIFacade myUIfacade;
+  private final UIFacade myUIfacade;
   private final ColumnList myVisibleFields = new VisibleFieldsImpl();
   final ColumnList myResourceVisibleFields = new VisibleFieldsImpl();
   //private final HumanResourceManager myBufferResourceManager;

--- a/ganttproject/src/main/java/net/sourceforge/ganttproject/storage/LazyProjectDatabaseProxy.kt
+++ b/ganttproject/src/main/java/net/sourceforge/ganttproject/storage/LazyProjectDatabaseProxy.kt
@@ -56,7 +56,7 @@ class LazyProjectDatabaseProxy(
     sm.stateTablesReady.await {
       sm.scope.launch {
         withContext(Dispatchers.IO) {
-          sm.transition(ProjectOpenActivityCalculatedModelReady(it.project)) {
+          sm.transition(ProjectOpenActivityCalculatedModelReady(it.project, it.document)) {
             projectEventListenerImpl.whenTablesInitialized(it.project)
           }
         }

--- a/ganttproject/src/main/java/net/sourceforge/ganttproject/storage/LazyProjectDatabaseProxy.kt
+++ b/ganttproject/src/main/java/net/sourceforge/ganttproject/storage/LazyProjectDatabaseProxy.kt
@@ -48,7 +48,7 @@ class LazyProjectDatabaseProxy(
   var projectOpenActivityFactory: ProjectOpenActivityFactory? = null
   set(value) {
     field = value
-    value?.addListener(this::onProjectOpenStateMachine)
+    value?.addBuilder(this::onProjectOpenStateMachine)
   }
 
   private fun onProjectOpenStateMachine(sm: ProjectOpenStateMachine) {

--- a/ganttproject/src/test/java/biz/ganttproject/app/BarriersTest.kt
+++ b/ganttproject/src/test/java/biz/ganttproject/app/BarriersTest.kt
@@ -21,6 +21,7 @@ package biz.ganttproject.app
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 
 class BarriersTest {
 
@@ -54,4 +55,24 @@ class BarriersTest {
     assertTrue(exitCalled)
   }
 
+  @Test
+  fun `two phase barrier can't be activated twice`() {
+    val barrier = TwoPhaseBarrierImpl<Boolean>("Bar1")
+    barrier.activate(true)
+    assertThrows<IllegalStateException> {
+      barrier.activate(false)
+    }
+  }
+
+  @Test
+  fun `exits are called immediately upon activation`() {
+    var exitCalled = false
+    val barrier = TwoPhaseBarrierImpl<Boolean>("Bar1")
+    barrier.await {
+      assertTrue(it)
+      exitCalled = true
+    }
+    barrier.activate(true)
+    assertTrue(exitCalled)
+  }
 }

--- a/ganttproject/src/test/java/biz/ganttproject/app/BarriersTest.kt
+++ b/ganttproject/src/test/java/biz/ganttproject/app/BarriersTest.kt
@@ -27,27 +27,30 @@ class BarriersTest {
   @Test
   fun `two phase barrier exit registered before entrance`() {
     var exitCalled = false
-    val barrier = TwoPhaseBarrierImpl<Boolean>("Bar1", true)
+    val barrier = TwoPhaseBarrierImpl<Boolean>("Bar1")
     barrier.await {
       assertTrue(it)
       exitCalled = true
     }
     assertFalse(exitCalled)
 
-    barrier.register("Entrance activity").let { entrance -> entrance() }
+    val entrance = barrier.register("Entrance activity")
+    barrier.activate(true)
+    entrance()
     assertTrue(exitCalled)
   }
 
   @Test
   fun `two phase barrier exit registered after entrance`() {
     var exitCalled = false
-    val barrier = TwoPhaseBarrierImpl<Boolean>("Bar1", true)
-    barrier.register("Entrance activity").let { entrance -> entrance() }
+    val barrier = TwoPhaseBarrierImpl<Boolean>("Bar1")
+    val entrance = barrier.register("Entrance activity")
+    barrier.activate(true)
+    entrance()
     barrier.await {
       assertTrue(it)
       exitCalled = true
     }
-    barrier.isActive = true
     assertTrue(exitCalled)
   }
 


### PR DESCRIPTION
```
### Summary

This pull request integrates more project opening logic into the Project-Open state machine. Three new states allow for waiting for "Document Ready" state and for handling document fork and authentication needed states.

Besides important bugfixes: 
 - a websocket would not open if we just open a cloud document
- chart would freeze when opening a cloud document (related to the Decorator implementation)
