### PR TITLE
Exit the application when quitting without saving

### DIFF
--- a/ganttproject/src/main/java/net/sourceforge/ganttproject/application/MainApplication.java
+++ b/ganttproject/src/main/java/net/sourceforge/ganttproject/application/MainApplication.java
@@ -100,10 +100,22 @@ public class MainApplication implements IPlatformRunnable {
     }
 
 
+    // The block below that waits on myLock is commented out, so nothing observes the notify()
+    // and launch() returns immediately. By the time the System.exit(0) further down is reached,
+    // myLock is still false and the process keeps running with its window open, even though
+    // quitApplication() has already saved the options and closed the project. Terminate here
+    // instead.
+    //
+    // withSystemExit is not always true: the updater passes false to restart rather than quit.
     Consumer<Boolean> onApplicationQuit = withSystemExit -> {
       synchronized(myLock) {
         myLock.set(withSystemExit);
         myLock.notify();
+      }
+      if (withSystemExit) {
+        logger.debug("Application quit requested, terminating");
+        GPLogger.close();
+        System.exit(0);
       }
     };
     GanttProject.setApplicationQuitCallback(onApplicationQuit);


### PR DESCRIPTION
### What fails

Modify a project, choose **Project → Exit**, then **Don't save**. The window stays open and the process keeps running.

Measured on the same machine, same steps:

| | process | window |
|---|---|---|
| before | PID alive, 576 MB, 65 threads | `* GanttProject[…]`, responsive |
| after | no java process | gone |

The last log line in both cases is `[GanttOptions] save(): finished!!` — `quitApplication()` completes correctly, saves the options and closes the project. Nothing then terminates the process.

### Why it happens

`MainApplication` sets `myLock` in the quit callback and calls `notify()`. The block that *waits* on it is commented out — from the commit "commented out or removed usages of the main application window". With no observer, `launch()` returns immediately, and the `System.exit(0)` further down is reached while `myLock` is still false.

### What this changes

The callback terminates directly when `withSystemExit` is true.

The condition matters: `withSystemExit` is not always true. Two call sites pass false, both in the updater — `PlatformOptionPage.kt:119` and `Update.kt:47` — where the intent is to restart rather than quit. The added block is skipped on that path, so restart behaviour is unchanged.

### What is not covered

I verified the updater path by reading it end to end (`quitApplication(false)` → `doQuitApplication` → `ourQuitCallback.accept(false)` → the condition is false, no exit), but I did not trigger it: that needs a real update available from the update service.

No test touches `MainApplication` — the change is covered by the manual before/after above, not by an automated test.