### PR TITLE
fix: Task Properties dialog: raw i18n keys and $Resources tab title

### DIFF
--- a/ganttproject/src/main/java/net/sourceforge/ganttproject/gui/taskproperties/TaskResourcesPanel.kt
+++ b/ganttproject/src/main/java/net/sourceforge/ganttproject/gui/taskproperties/TaskResourcesPanel.kt
@@ -22,6 +22,7 @@ import biz.ganttproject.app.FXThread
 import biz.ganttproject.app.PropertyPane
 import biz.ganttproject.app.PropertyPaneBuilderImpl
 import biz.ganttproject.app.RootLocalizer
+import biz.ganttproject.app.removeMnemonicsPlaceholder
 import biz.ganttproject.core.option.ObservableBoolean
 import biz.ganttproject.core.option.ObservableMoney
 import javafx.beans.property.SimpleBooleanProperty
@@ -102,7 +103,7 @@ class TaskResourcesPanel(
   private val costIsCalculated = ObservableBoolean("option.taskProperties.cost.calculated.label", task.cost.isCalculated)
   private val costValue = ObservableMoney("option.taskProperties.cost.value", task.cost.value)
 
-  val title: String = i18n.formatText("human")
+  val title: String = i18n.formatText("human").removeMnemonicsPlaceholder()
   private val tableAndActions = AbstractTableAndActionsComponentFx(tableView, model)
 
   val fxComponent by lazy {


### PR DESCRIPTION
Fixes #2800

## Root cause

Resources tab title not stripped of legacy Swing mnemonic marker

## Changes

- Apply removeMnemonicsPlaceholder() to the localized "human" string used as the Resources tab title in TaskResourcesPanel.kt. Bug 1 (raw i18n keys in MainPropertiesPanel.kt) is already fixed in the checked-out revision by commit 47f1430c2, so no change was made there.