### PR TITLE
fix: Logo is not scaled down in PDF export

### DIFF
--- a/ganttproject/src/main/java/net/sourceforge/ganttproject/chart/PrintChartApiImpl.kt
+++ b/ganttproject/src/main/java/net/sourceforge/ganttproject/chart/PrintChartApiImpl.kt
@@ -25,6 +25,7 @@ import net.sourceforge.ganttproject.gui.zoom.ZoomManager
 import java.awt.Color
 import java.awt.Graphics2D
 import java.awt.Image
+import java.awt.RenderingHints
 import java.awt.image.BufferedImage
 import java.util.*
 
@@ -70,9 +71,10 @@ internal class ChartRasterImageBuilder : ChartImageVisitor {
     val g = getGraphics(d)
     g!!.background = Color.WHITE
     g.clearRect(0, 0, d.treeWidth, d.logoHeight)
-    // Hack: by adding 35, the left part of the logo becomes visible,
-    // otherwise it gets chopped off
-    g.drawImage(logo, 0, 0, null)
+    if (logo != null && d.logoWidth > 0 && d.logoHeight > 0) {
+      g.setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_BILINEAR)
+      g.drawImage(logo, 0, 0, d.logoWidth, d.logoHeight, null)
+    }
   }
 
   override fun acceptTable(d: ChartDimensions, treeTable: TreeTableApi) {

--- a/ganttproject/src/main/java/net/sourceforge/ganttproject/chart/export/ChartDimensions.kt
+++ b/ganttproject/src/main/java/net/sourceforge/ganttproject/chart/export/ChartDimensions.kt
@@ -19,9 +19,19 @@ along with GanttProject.  If not, see <http://www.gnu.org/licenses/>.
 package net.sourceforge.ganttproject.chart.export
 
 import net.sourceforge.ganttproject.GanttExportSettings
+import net.sourceforge.ganttproject.gui.UIFacade
+import kotlin.math.min
+import kotlin.math.roundToInt
 
 class ChartDimensions internal constructor(settings: GanttExportSettings, treeTable: TreeTableApi) {
-  val logoHeight: Int = settings.logo.getHeight(null)
+  private val logoSourceWidth: Int = settings.logo?.getWidth(null) ?: -1
+  private val logoSourceHeight: Int = settings.logo?.getHeight(null) ?: -1
+  val logoHeight: Int =
+    if (logoSourceWidth <= 0 || logoSourceHeight <= 0) 0
+    else min(logoSourceHeight, UIFacade.DEFAULT_LOGO.iconHeight)
+  val logoWidth: Int =
+    if (logoHeight == 0) 0
+    else (logoSourceWidth.toDouble() * logoHeight / logoSourceHeight).roundToInt()
   val treeHeight: Int = treeTable.rowHeight() * settings.rowCount
   val tableHeaderHeight: Int = treeTable.tableHeaderHeight()
   val treeWidth: Int = treeTable.width(settings.isCommandLineMode)

--- a/org.ganttproject.impex.htmlpdf/src/main/java/org/ganttproject/impex/htmlpdf/itext/ChartWriter.java
+++ b/org.ganttproject.impex.htmlpdf/src/main/java/org/ganttproject/impex/htmlpdf/itext/ChartWriter.java
@@ -103,7 +103,9 @@ class ChartWriter implements ChartImageVisitor {
     Graphics2D g = getGraphics(d);
     g.setBackground(Color.WHITE);
     g.clearRect(0, 0, d.getTreeWidth(), d.getLogoHeight());
-    g.drawImage(logo, 0, 0, null);
+    if (logo != null && d.getLogoWidth() > 0 && d.getLogoHeight() > 0) {
+      g.drawImage(logo, 0, 0, d.getLogoWidth(), d.getLogoHeight(), null);
+    }
   }
 
   @Override


### PR DESCRIPTION
Fixes #2613

## Root cause

Export path draws the project logo at native size instead of scaling it

## Changes

- ChartDimensions now caps the logo height at the default logo height (47px, same height the app window renders the logo at) and exposes an aspect-ratio-preserving logoWidth; both export visitors (iText PDF ChartWriter and the raster PNG/print builder) draw the logo scaled into that box and tolerate a null logo. Added a unit test for the new dimension arithmetic.