### PR TITLE
Store decimal custom properties as double precision instead of numeric

### DIFF
--- a/ganttproject/src/main/java/net/sourceforge/ganttproject/storage/SqlCustomPropertyStorageManager.kt
+++ b/ganttproject/src/main/java/net/sourceforge/ganttproject/storage/SqlCustomPropertyStorageManager.kt
@@ -106,5 +106,5 @@ private fun CustomPropertyClass.asSqlType() = when (this) {
   CustomPropertyClass.INTEGER -> "integer"
   CustomPropertyClass.DATE -> "date"
   CustomPropertyClass.BOOLEAN -> "boolean"
-  CustomPropertyClass.DOUBLE -> "numeric"
+  CustomPropertyClass.DOUBLE -> "double precision"
 }

--- a/ganttproject/src/test/java/biz/ganttproject/storage/SqlCustomPropertyStorageManagerTest.kt
+++ b/ganttproject/src/test/java/biz/ganttproject/storage/SqlCustomPropertyStorageManagerTest.kt
@@ -176,6 +176,25 @@ class CalculatedPropertyTest {
     }
     manager.onCustomColumnChange(customPropertyManager)
   }
+
+  @Test
+  fun `decimal custom property keeps its fractional part`() {
+    val foo = customPropertyManager.createDefinition(CustomPropertyClass.DOUBLE, "foo")
+    rebuildTaskDataTable(dataSource, customPropertyManager)
+
+    val task = taskManager.newTaskBuilder().withName("task1").withStartDate(Date()).build()
+    task.customValues.setValue(foo, 12.5)
+    projectDatabase.insertTask(task)
+
+    dataSource.connection.use { conn ->
+      conn.createStatement().use { stmt ->
+        stmt.executeQuery("SELECT ${foo.id} FROM Task").use { rs ->
+          assert(rs.next())
+          assertEquals(12.5, rs.getDouble(1))
+        }
+      }
+    }
+  }
 }
 
 private fun createPropertyHolders(taskManager: TaskManager) =


### PR DESCRIPTION
### What fails

Every user-defined column of type Decimal is rounded to a whole number in the
mirror database. A task with 12.5 in such a column comes back as 13.

### Why it happens

`asSqlType()` in `SqlCustomPropertyStorageManager.kt` maps
`CustomPropertyClass.DOUBLE` to the SQL type `numeric`, with no precision or
scale. The SQL standard requires a default scale of zero for that, i.e.
coercion to integer precision, and H2 follows the standard here: since 2.0.202
a `DECIMAL`/`NUMERIC` column declared without parameters has scale 0 and cannot
hold a fractional part (H2 migration notes for version 2).

Worth noting why this was never caught: the existing tests all use whole
numbers, so the rounding is invisible in them.

### What this changes

One line: `CustomPropertyClass.DOUBLE` is mapped to `double precision` instead
of `numeric`. Nothing else in the mapping is touched.

### Verified

A regression test was added as a `@Test` method to the existing test class in
`SqlCustomPropertyStorageManagerTest.kt`. It uses an ordinary `DOUBLE` custom
property with the value 12.5, inserts the task, and reads the value back from
the mirror table. It uses no fork-specific class or column.

| | without the fix | with the fix |
|---|---|---|
| the new test | `expected: <12.5> but was: <13.0>` | passes |
| its enclosing class | 6 tests, 1 failure | 6 tests, 0 failures |
| full run on the branch | — | 352 tests, 0 errors, 0 skipped, 1 unrelated failure |

352 is the 351 of the base commit plus the one added here.

### What is not covered

The full run was done on Windows only. The one failure in it is
`GPCloudDocumentTest.testMirroredAutomaticallyWhenHasOptions`, which is the
Windows path problem addressed in #2821 and unrelated to this change; it does
not occur on Linux. The fix itself is not platform-dependent — the rounding
happens in H2 regardless.

Existing mirror databases were not examined. If a mirror table is kept across
restarts rather than rebuilt, a column created under the old mapping would keep
its scale, and values already rounded are already lost. Whether that situation
can arise is a question about the mirror database lifecycle rather than about
this mapping.

The other entries in `asSqlType()` were not audited for the same class of
problem.