### PR TITLE
Notify listeners when days off are removed, and add the missing removal methods

### DIFF
--- a/biz.ganttproject.impex.msproject2/src/main/java/biz/ganttproject/impex/msproject2/ProjectFileExporter.java
+++ b/biz.ganttproject.impex.msproject2/src/main/java/biz/ganttproject/impex/msproject2/ProjectFileExporter.java
@@ -45,7 +45,6 @@ import net.sourceforge.ganttproject.task.TaskManager;
 import net.sourceforge.ganttproject.task.dependency.TaskDependency;
 import net.sourceforge.ganttproject.task.dependency.TaskDependencySlice;
 
-import javax.swing.*;
 import java.math.BigDecimal;
 import java.text.SimpleDateFormat;
 import java.time.DayOfWeek;
@@ -55,6 +54,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
@@ -395,7 +395,7 @@ class ProjectFileExporter {
   }
 
   private void exportDaysOff(HumanResource hr, Resource mpxjResource) throws MPXJException {
-    DefaultListModel daysOff = hr.getDaysOff();
+    List<GanttDaysOff> daysOff = hr.getDaysOff();
     if (!daysOff.isEmpty()) {
       ProjectCalendar resourceCalendar = mpxjResource.addCalendar();
       resourceCalendar.addDefaultCalendarHours();
@@ -403,7 +403,7 @@ class ProjectFileExporter {
       resourceCalendar.setParent(myOutputProject.getDefaultCalendar());
       // resourceCalendar.setUniqueID(hr.getId());
       for (int i = 0; i < daysOff.size(); i++) {
-        GanttDaysOff dayOff = (GanttDaysOff) daysOff.get(i);
+        GanttDaysOff dayOff = daysOff.get(i);
         resourceCalendar.addCalendarException(toLocalDate(dayOff.getStart().getTime()), toLocalDate(dayOff.getFinish().getTime()));
       }
     }

--- a/ganttproject-tester/test/net/sourceforge/ganttproject/resource/HumanResourceDaysOffTest.kt
+++ b/ganttproject-tester/test/net/sourceforge/ganttproject/resource/HumanResourceDaysOffTest.kt
@@ -1,0 +1,85 @@
+/*
+Copyright 2026 BarD Software s.r.o
+
+This file is part of GanttProject, an open-source project management tool.
+
+GanttProject is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+GanttProject is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with GanttProject.  If not, see <http://www.gnu.org/licenses/>.
+*/
+package net.sourceforge.ganttproject.resource
+
+import biz.ganttproject.core.time.CalendarFactory
+import biz.ganttproject.core.calendar.GanttDaysOff
+import biz.ganttproject.customproperty.CustomColumnsManager
+import net.sourceforge.ganttproject.roles.Role
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import java.text.DateFormat
+import java.util.Date
+import java.util.Locale
+
+/**
+ * Adding and removing days off must be symmetric with respect to notification: whoever listens to
+ * a resource has to learn about both, because both change the resource's load distribution.
+ *
+ * Adding goes through [HumanResource.addDaysOff], which resets the loads and fires. Removing has no
+ * such entry point at all -- the only way is to mutate the list handed out by
+ * [HumanResource.getDaysOff], and that list is not observed.
+ */
+class HumanResourceDaysOffTest {
+  init {
+    // GanttDaysOff builds GanttCalendars, and those need a locale.
+    object : CalendarFactory() {
+      init {
+        setLocaleApi(object : CalendarFactory.LocaleApi {
+          override fun getLocale(): Locale = Locale.GERMANY
+          override fun getShortDateFormat(): DateFormat =
+            DateFormat.getDateInstance(DateFormat.SHORT, Locale.GERMANY)
+        })
+      }
+    }
+  }
+
+  private class CountingView : ResourceView {
+    var changed = 0
+    override fun resourceAdded(event: ResourceEvent) {}
+    override fun resourcesRemoved(event: ResourceEvent) {}
+    override fun resourceChanged(e: ResourceEvent) { changed++ }
+    override fun resourceAssignmentsChanged(e: ResourceEvent) {}
+    override fun resourceStructureChanged() {}
+    override fun resourceModelReset() {}
+  }
+
+  private fun september(day: Int): Date = CalendarFactory.createGanttCalendar(2026, 8, day).time
+
+  @Test
+  fun `removing the last day off notifies the listeners just as adding it does`() {
+    val manager = HumanResourceManager(null as Role?, CustomColumnsManager())
+    val person = manager.newHumanResource()
+    person.name = "Tester"
+    manager.add(person)
+
+    val view = CountingView()
+    manager.addView(view)
+
+    person.addDaysOff(GanttDaysOff(september(9), september(10)))
+    assertEquals(1, view.changed, "adding a day off must notify the listeners")
+
+    view.changed = 0
+    person.daysOff.clear()
+    assertEquals(
+      1, view.changed,
+      "removing the LAST day off must notify the listeners too -- otherwise nobody recalculates"
+    )
+  }
+}

--- a/ganttproject-tester/test/net/sourceforge/ganttproject/resource/HumanResourceDaysOffTest.kt
+++ b/ganttproject-tester/test/net/sourceforge/ganttproject/resource/HumanResourceDaysOffTest.kt
@@ -32,9 +32,10 @@ import java.util.Locale
  * Adding and removing days off must be symmetric with respect to notification: whoever listens to
  * a resource has to learn about both, because both change the resource's load distribution.
  *
- * Adding goes through [HumanResource.addDaysOff], which resets the loads and fires. Removing has no
- * such entry point at all -- the only way is to mutate the list handed out by
- * [HumanResource.getDaysOff], and that list is not observed.
+ * Adding goes through [HumanResource.addDaysOff], which resets the loads and fires. Removing the
+ * last one used to notify nobody: there was no entry point for it, and the only way was to mutate
+ * the list handed out by [HumanResource.getDaysOff], which nothing was watching. Removing now goes
+ * through [HumanResource.clearDaysOff], which fires just as adding does.
  */
 class HumanResourceDaysOffTest {
   init {
@@ -76,7 +77,7 @@ class HumanResourceDaysOffTest {
     assertEquals(1, view.changed, "adding a day off must notify the listeners")
 
     view.changed = 0
-    person.daysOff.clear()
+    person.clearDaysOff()
     assertEquals(
       1, view.changed,
       "removing the LAST day off must notify the listeners too -- otherwise nobody recalculates"

--- a/ganttproject-tester/test/net/sourceforge/ganttproject/resource/HumanResourceDaysOffViewTest.kt
+++ b/ganttproject-tester/test/net/sourceforge/ganttproject/resource/HumanResourceDaysOffViewTest.kt
@@ -1,0 +1,107 @@
+/*
+Copyright 2026 BarD Software s.r.o
+
+This file is part of GanttProject, an open-source project management tool.
+
+GanttProject is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+GanttProject is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with GanttProject.  If not, see <http://www.gnu.org/licenses/>.
+*/
+package net.sourceforge.ganttproject.resource
+
+import biz.ganttproject.core.calendar.GanttDaysOff
+import biz.ganttproject.core.time.CalendarFactory
+import biz.ganttproject.customproperty.CustomColumnsManager
+import net.sourceforge.ganttproject.roles.Role
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.text.DateFormat
+import java.util.Date
+import java.util.Locale
+
+/**
+ * [HumanResource.getDaysOff] hands out an unmodifiable view of the resource's days off. These two
+ * tests pin both halves of that sentence.
+ *
+ * Unmodifiable is what makes the notification correct: every change now goes through addDaysOff,
+ * removeDaysOff or clearDaysOff, and each of them resets the load distribution and fires. A caller
+ * able to mutate the handed-out list could change the resource behind the back of both.
+ *
+ * A view rather than a copy is what keeps the list cheap and current: a caller holding on to it
+ * keeps seeing the resource, and no caller in the tree is handed a snapshot that silently goes
+ * stale.
+ */
+class HumanResourceDaysOffViewTest {
+  init {
+    // GanttDaysOff builds GanttCalendars, and those need a locale.
+    object : CalendarFactory() {
+      init {
+        setLocaleApi(object : CalendarFactory.LocaleApi {
+          override fun getLocale(): Locale = Locale.GERMANY
+          override fun getShortDateFormat(): DateFormat =
+            DateFormat.getDateInstance(DateFormat.SHORT, Locale.GERMANY)
+        })
+      }
+    }
+  }
+
+  private fun september(day: Int): Date = CalendarFactory.createGanttCalendar(2026, 8, day).time
+
+  private fun daysOff(from: Int, to: Int) = GanttDaysOff(september(from), september(to))
+
+  private fun newPerson(): HumanResource {
+    val manager = HumanResourceManager(null as Role?, CustomColumnsManager())
+    val person = manager.newHumanResource()
+    person.name = "Tester"
+    manager.add(person)
+    return person
+  }
+
+  @Test
+  fun `the list handed out by getDaysOff cannot be modified`() {
+    val person = newPerson()
+    person.addDaysOff(daysOff(9, 10))
+    val handedOut = person.daysOff
+
+    assertThrows<UnsupportedOperationException>("clearing the handed-out list must not be possible") {
+      handedOut.clear()
+    }
+    assertThrows<UnsupportedOperationException>("adding to the handed-out list must not be possible") {
+      handedOut.add(0, daysOff(20, 21))
+    }
+    assertThrows<UnsupportedOperationException>("removing from the handed-out list must not be possible") {
+      handedOut.removeAt(0)
+    }
+    assertThrows<UnsupportedOperationException>("overwriting in the handed-out list must not be possible") {
+      handedOut.set(0, daysOff(20, 21))
+    }
+
+    assertEquals(1, person.daysOff.size, "none of the rejected calls may have changed the resource")
+  }
+
+  @Test
+  fun `the list handed out by getDaysOff is a view and not a copy`() {
+    val person = newPerson()
+    person.addDaysOff(daysOff(9, 10))
+
+    val handedOut = person.daysOff
+    assertEquals(1, handedOut.size, "the day off given before the call must be in the handed-out list")
+
+    person.addDaysOff(daysOff(20, 21))
+    assertEquals(
+      2, handedOut.size,
+      "a day off given AFTER the call must show up too -- a copy would still show one"
+    )
+    assertEquals(daysOff(20, 21).start, handedOut.get(1).start, "and it must be the new interval")
+  }
+}

--- a/ganttproject-tester/test/net/sourceforge/ganttproject/resource/HumanResourceRemoveDaysOffTest.kt
+++ b/ganttproject-tester/test/net/sourceforge/ganttproject/resource/HumanResourceRemoveDaysOffTest.kt
@@ -1,0 +1,184 @@
+/*
+Copyright 2026 BarD Software s.r.o
+
+This file is part of GanttProject, an open-source project management tool.
+
+GanttProject is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+GanttProject is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with GanttProject.  If not, see <http://www.gnu.org/licenses/>.
+*/
+package net.sourceforge.ganttproject.resource
+
+import biz.ganttproject.core.calendar.GanttDaysOff
+import biz.ganttproject.core.time.CalendarFactory
+import biz.ganttproject.customproperty.CustomColumnsManager
+import net.sourceforge.ganttproject.roles.Role
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.text.DateFormat
+import java.util.Date
+import java.util.Locale
+
+/**
+ * A resource can be given a day off through [HumanResource.addDaysOff], but until now it could only
+ * be taken away again by reaching into the list handed out by [HumanResource.getDaysOff] and
+ * mutating it. These tests pin the counterpart of addDaysOff: [HumanResource.removeDaysOff] for a
+ * single interval and [HumanResource.clearDaysOff] for all of them, both notifying exactly like the
+ * mutation of the handed-out list does.
+ *
+ * Every one of the five tests below was seen to fail against the state before this change, each with
+ * its own error. The failure is a Kotlin compilation error rather than a failed assertion, because
+ * the methods being pinned did not exist yet -- there is no way to name a method that is not there
+ * and still compile. The verbatim output of that run is quoted at each test method; the line and
+ * column numbers in it refer to this file as it stood in that run, before these very comments were
+ * added, so they no longer point at the quoted line.
+ */
+class HumanResourceRemoveDaysOffTest {
+  init {
+    // GanttDaysOff builds GanttCalendars, and those need a locale.
+    object : CalendarFactory() {
+      init {
+        setLocaleApi(object : CalendarFactory.LocaleApi {
+          override fun getLocale(): Locale = Locale.GERMANY
+          override fun getShortDateFormat(): DateFormat =
+            DateFormat.getDateInstance(DateFormat.SHORT, Locale.GERMANY)
+        })
+      }
+    }
+  }
+
+  private class CountingView : ResourceView {
+    var changed = 0
+    override fun resourceAdded(event: ResourceEvent) {}
+    override fun resourcesRemoved(event: ResourceEvent) {}
+    override fun resourceChanged(e: ResourceEvent) { changed++ }
+    override fun resourceAssignmentsChanged(e: ResourceEvent) {}
+    override fun resourceStructureChanged() {}
+    override fun resourceModelReset() {}
+  }
+
+  private fun september(day: Int): Date = CalendarFactory.createGanttCalendar(2026, 8, day).time
+
+  private fun daysOff(from: Int, to: Int) = GanttDaysOff(september(from), september(to))
+
+  /** A manager with one resource in it, plus a view counting the resourceChanged notifications. */
+  private fun newPersonWithView(): Pair<HumanResource, CountingView> {
+    val manager = HumanResourceManager(null as Role?, CustomColumnsManager())
+    val person = manager.newHumanResource()
+    person.name = "Tester"
+    manager.add(person)
+    val view = CountingView()
+    manager.addView(view)
+    return person to view
+  }
+
+  // Red before the change:
+  // e: file:///.../HumanResourceRemoveDaysOffTest.kt:88:23 Unresolved reference 'removeDaysOff'.
+  @Test
+  fun `removing a single day off takes it off the resource and notifies once`() {
+    val (person, view) = newPersonWithView()
+    val first = daysOff(9, 10)
+    val second = daysOff(20, 21)
+    person.addDaysOff(first)
+    person.addDaysOff(second)
+
+    view.changed = 0
+    assertTrue(person.removeDaysOff(first), "removeDaysOff must report that it removed something")
+
+    assertEquals(1, view.changed, "removing a day off must notify the listeners exactly once")
+    assertEquals(1, person.daysOff.size, "the other day off must still be there")
+    assertEquals(second, person.daysOff.get(0), "the WRONG day off was removed")
+  }
+
+  // Red before the change:
+  // e: file:///.../HumanResourceRemoveDaysOffTest.kt:105:24 Unresolved reference 'removeDaysOff'.
+  @Test
+  fun `removing a day off the resource does not have changes nothing and notifies nobody`() {
+    val (person, view) = newPersonWithView()
+    person.addDaysOff(daysOff(9, 10))
+
+    view.changed = 0
+    // Deliberately an interval the resource has never been given. GanttDaysOff does not override
+    // equals(Object) -- it only overloads equals(GanttDaysOff) -- so an interval with the very same
+    // dates is still a different one as far as the list is concerned. That is the behaviour pinned
+    // here, so that it cannot change unnoticed.
+    assertFalse(person.removeDaysOff(daysOff(9, 10)), "an interval that is not there cannot be removed")
+
+    assertEquals(0, view.changed, "a removal that removed nothing must not notify anybody")
+    assertEquals(1, person.daysOff.size, "the existing day off must be untouched")
+  }
+
+  // Red before the change:
+  // e: file:///.../HumanResourceRemoveDaysOffTest.kt:119:12 Unresolved reference 'clearDaysOff'.
+  @Test
+  fun `clearing the days off empties the list and notifies once, whatever the count`() {
+    val (person, view) = newPersonWithView()
+    person.addDaysOff(daysOff(9, 10))
+    person.addDaysOff(daysOff(20, 21))
+    person.addDaysOff(daysOff(24, 25))
+
+    view.changed = 0
+    person.clearDaysOff()
+
+    assertEquals(0, person.daysOff.size, "clearDaysOff must leave no day off behind")
+    assertEquals(1, view.changed, "clearing three days off must notify exactly once, as clear() does")
+  }
+
+  // Red before the change:
+  // e: file:///.../HumanResourceRemoveDaysOffTest.kt:130:12 Unresolved reference 'clearDaysOff'.
+  @Test
+  fun `clearing an empty list of days off notifies nobody`() {
+    val (person, view) = newPersonWithView()
+
+    view.changed = 0
+    person.clearDaysOff()
+
+    assertEquals(0, view.changed, "there was nothing to remove, so there is nothing to report")
+  }
+
+  /**
+   * The one caller in the tree, GanttDialogPerson.applyChanges(), throws all the intervals away and
+   * writes the edited ones back. This pins that going through clearDaysOff() instead of reaching
+   * into the handed-out list costs the very same number of notifications -- neither more (which
+   * would be a regression) nor zero where there used to be one.
+   *
+   * Red before the change:
+   * e: file:///.../HumanResourceRemoveDaysOffTest.kt:157:19 Unresolved reference 'clearDaysOff'.
+   */
+  @Test
+  fun `the dialog's clear-all-and-rewrite costs the same notifications either way`() {
+    // M = intervals before the Ok, N = intervals in the dialog when Ok is pressed.
+    for (m in 0..3) {
+      for (n in 0..3) {
+        val expected = (if (m > 0) 1 else 0) + n
+
+        val (viaList, listView) = newPersonWithView()
+        repeat(m) { viaList.addDaysOff(daysOff(it + 1, it + 2)) }
+        listView.changed = 0
+        viaList.daysOff.clear()
+        repeat(n) { viaList.addDaysOff(daysOff(it + 10, it + 11)) }
+
+        val (viaMethod, methodView) = newPersonWithView()
+        repeat(m) { viaMethod.addDaysOff(daysOff(it + 1, it + 2)) }
+        methodView.changed = 0
+        viaMethod.clearDaysOff()
+        repeat(n) { viaMethod.addDaysOff(daysOff(it + 10, it + 11)) }
+
+        assertEquals(expected, listView.changed, "M=$m N=$n: the old way through the handed-out list")
+        assertEquals(expected, methodView.changed, "M=$m N=$n: the new way through clearDaysOff()")
+        assertEquals(n, viaMethod.daysOff.size, "M=$m N=$n: the rewritten intervals must be the only ones")
+      }
+    }
+  }
+}

--- a/ganttproject-tester/test/net/sourceforge/ganttproject/resource/HumanResourceRemoveDaysOffTest.kt
+++ b/ganttproject-tester/test/net/sourceforge/ganttproject/resource/HumanResourceRemoveDaysOffTest.kt
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import java.text.DateFormat
 import java.util.Date
 import java.util.Locale
@@ -149,15 +150,18 @@ class HumanResourceRemoveDaysOffTest {
 
   /**
    * The one caller in the tree, GanttDialogPerson.applyChanges(), throws all the intervals away and
-   * writes the edited ones back. This pins that going through clearDaysOff() instead of reaching
-   * into the handed-out list costs the very same number of notifications -- neither more (which
+   * writes the edited ones back. This pins the cost of that at (M > 0 ? 1 : 0) + N notifications --
+   * the very number a caller reaching into the handed-out list used to pay, neither more (which
    * would be a regression) nor zero where there used to be one.
+   *
+   * That old way is pinned too, from the other side: getDaysOff() hands out an unmodifiable view
+   * now, so reaching into it changes nothing and reports nothing.
    *
    * Red before the change:
    * e: file:///.../HumanResourceRemoveDaysOffTest.kt:157:19 Unresolved reference 'clearDaysOff'.
    */
   @Test
-  fun `the dialog's clear-all-and-rewrite costs the same notifications either way`() {
+  fun `the dialog's clear-all-and-rewrite still costs the same notifications`() {
     // M = intervals before the Ok, N = intervals in the dialog when Ok is pressed.
     for (m in 0..3) {
       for (n in 0..3) {
@@ -166,8 +170,11 @@ class HumanResourceRemoveDaysOffTest {
         val (viaList, listView) = newPersonWithView()
         repeat(m) { viaList.addDaysOff(daysOff(it + 1, it + 2)) }
         listView.changed = 0
-        viaList.daysOff.clear()
-        repeat(n) { viaList.addDaysOff(daysOff(it + 10, it + 11)) }
+        assertThrows<UnsupportedOperationException>("M=$m N=$n: the old way must be rejected") {
+          viaList.daysOff.clear()
+        }
+        assertEquals(m, viaList.daysOff.size, "M=$m N=$n: the rejected call must not have removed anything")
+        assertEquals(0, listView.changed, "M=$m N=$n: the rejected call must not have notified anybody")
 
         val (viaMethod, methodView) = newPersonWithView()
         repeat(m) { viaMethod.addDaysOff(daysOff(it + 1, it + 2)) }
@@ -175,8 +182,7 @@ class HumanResourceRemoveDaysOffTest {
         viaMethod.clearDaysOff()
         repeat(n) { viaMethod.addDaysOff(daysOff(it + 10, it + 11)) }
 
-        assertEquals(expected, listView.changed, "M=$m N=$n: the old way through the handed-out list")
-        assertEquals(expected, methodView.changed, "M=$m N=$n: the new way through clearDaysOff()")
+        assertEquals(expected, methodView.changed, "M=$m N=$n: the way through clearDaysOff()")
         assertEquals(n, viaMethod.daysOff.size, "M=$m N=$n: the rewritten intervals must be the only ones")
       }
     }

--- a/ganttproject/src/main/java/net/sourceforge/ganttproject/gui/GanttDialogPerson.java
+++ b/ganttproject/src/main/java/net/sourceforge/ganttproject/gui/GanttDialogPerson.java
@@ -165,7 +165,7 @@ public class GanttDialogPerson {
       return null;
     });
 
-    person.getDaysOff().clear();
+    person.clearDaysOff();
     for (DateInterval interval : myDaysOffModel.getIntervals()) {
       person.addDaysOff(new GanttDaysOff(interval.getStart(), interval.getEnd()));
     }

--- a/ganttproject/src/main/java/net/sourceforge/ganttproject/gui/GanttDialogPerson.java
+++ b/ganttproject/src/main/java/net/sourceforge/ganttproject/gui/GanttDialogPerson.java
@@ -36,6 +36,7 @@ import net.sourceforge.ganttproject.task.TaskManager;
 
 import javax.swing.*;
 import java.awt.event.ActionEvent;
+import java.util.List;
 
 public class GanttDialogPerson {
   private static final GanttLanguage language = GanttLanguage.getInstance();
@@ -191,8 +192,8 @@ public class GanttDialogPerson {
         super.remove(interval);
       }
     };
-    DefaultListModel<GanttDaysOff> daysOff = person.getDaysOff();
-    for (int i = 0; i < daysOff.getSize(); i++) {
+    List<GanttDaysOff> daysOff = person.getDaysOff();
+    for (int i = 0; i < daysOff.size(); i++) {
       GanttDaysOff next = daysOff.get(i);
       myDaysOffModel.add(DateInterval.Companion.createFromModelDates(next.getStart().getTime(),
           next.getFinish().getTime()));

--- a/ganttproject/src/main/java/net/sourceforge/ganttproject/io/VacationSaver.java
+++ b/ganttproject/src/main/java/net/sourceforge/ganttproject/io/VacationSaver.java
@@ -36,7 +36,7 @@ class VacationSaver extends SaverBase {
     for (HumanResource p : project.getHumanResourceManager().getResources()) {
       if (p.getDaysOff() != null)
         for (int j = 0; j < p.getDaysOff().size(); j++) {
-          GanttDaysOff gdo = (GanttDaysOff) p.getDaysOff().getElementAt(j);
+          GanttDaysOff gdo = p.getDaysOff().get(j);
           addAttribute("start", gdo.getStart().toXMLString(), attrs);
           addAttribute("end", gdo.getFinish().toXMLString(), attrs);
           addAttribute("resourceid", p.getId(), attrs);

--- a/ganttproject/src/main/java/net/sourceforge/ganttproject/resource/HumanResource.java
+++ b/ganttproject/src/main/java/net/sourceforge/ganttproject/resource/HumanResource.java
@@ -28,6 +28,8 @@ import net.sourceforge.ganttproject.task.ResourceAssignment;
 import net.sourceforge.ganttproject.task.Task;
 
 import javax.swing.*;
+import javax.swing.event.ListDataEvent;
+import javax.swing.event.ListDataListener;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -60,6 +62,37 @@ public class HumanResource implements CustomPropertyHolder {
   private BigDecimal myStandardPayRate;
 
   private final DefaultListModel<GanttDaysOff> myDaysOffList = new DefaultListModel<>();
+
+  {
+    // The days off list is handed out by getDaysOff(), and callers mutate it directly -- the
+    // resource properties dialog, for instance, clears it before writing the edited intervals
+    // back. Such a mutation changes the resource's load distribution just as addDaysOff() does, so
+    // it has to reset the loads and notify the listeners. Watching the list covers every caller at
+    // once, including the removal of the LAST interval, which used to notify nobody.
+    //
+    // During the copying constructor areEventsEnabled is false, so copying stays silent.
+    myDaysOffList.addListDataListener(new ListDataListener() {
+      @Override
+      public void intervalAdded(ListDataEvent e) {
+        onDaysOffChanged();
+      }
+
+      @Override
+      public void intervalRemoved(ListDataEvent e) {
+        onDaysOffChanged();
+      }
+
+      @Override
+      public void contentsChanged(ListDataEvent e) {
+        onDaysOffChanged();
+      }
+    });
+  }
+
+  private void onDaysOffChanged() {
+    resetLoads();
+    fireResourceChanged();
+  }
 
   private final List<ResourceAssignment> myAssignments = new ArrayList<>();
 
@@ -184,9 +217,9 @@ public class HumanResource implements CustomPropertyHolder {
 
   public void addDaysOff(GanttDaysOff gdo) {
     System.out.println("add day off: " + gdo.getStart() + " - " + gdo.getFinish() + "");
-    resetLoads();
+    // resetLoads() and fireResourceChanged() are done by the list listener installed above, for
+    // this call and for every other mutation of the list alike.
     myDaysOffList.addElement(gdo);
-    fireResourceChanged();
   }
 
   public DefaultListModel<GanttDaysOff> getDaysOff() {

--- a/ganttproject/src/main/java/net/sourceforge/ganttproject/resource/HumanResource.java
+++ b/ganttproject/src/main/java/net/sourceforge/ganttproject/resource/HumanResource.java
@@ -27,9 +27,6 @@ import net.sourceforge.ganttproject.roles.Role;
 import net.sourceforge.ganttproject.task.ResourceAssignment;
 import net.sourceforge.ganttproject.task.Task;
 
-import javax.swing.*;
-import javax.swing.event.ListDataEvent;
-import javax.swing.event.ListDataListener;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -61,34 +58,21 @@ public class HumanResource implements CustomPropertyHolder {
 
   private BigDecimal myStandardPayRate;
 
-  private final DefaultListModel<GanttDaysOff> myDaysOffList = new DefaultListModel<>();
+  private final List<GanttDaysOff> myDaysOffList = new ArrayList<>();
 
-  {
-    // The days off list is handed out by getDaysOff(), and callers mutate it directly -- the
-    // resource properties dialog, for instance, clears it before writing the edited intervals
-    // back. Such a mutation changes the resource's load distribution just as addDaysOff() does, so
-    // it has to reset the loads and notify the listeners. Watching the list covers every caller at
-    // once, including the removal of the LAST interval, which used to notify nobody.
-    //
-    // During the copying constructor areEventsEnabled is false, so copying stays silent.
-    myDaysOffList.addListDataListener(new ListDataListener() {
-      @Override
-      public void intervalAdded(ListDataEvent e) {
-        onDaysOffChanged();
-      }
+  /**
+   * What getDaysOff() hands out: a view, so that a caller holding on to it keeps seeing the
+   * resource, and unmodifiable, so that the only ways in are addDaysOff, removeDaysOff and
+   * clearDaysOff. Every one of those resets the load distribution and notifies -- a caller able to
+   * mutate the list directly could change the resource behind the back of both.
+   */
+  private final List<GanttDaysOff> myDaysOffView = Collections.unmodifiableList(myDaysOffList);
 
-      @Override
-      public void intervalRemoved(ListDataEvent e) {
-        onDaysOffChanged();
-      }
-
-      @Override
-      public void contentsChanged(ListDataEvent e) {
-        onDaysOffChanged();
-      }
-    });
-  }
-
+  /**
+   * Called by every method that changes the days off, after it really changed something. A day off
+   * shifts this resource's load distribution just as an assignment does, so the cached distribution
+   * has to go and whoever watches the resource has to hear about it.
+   */
   private void onDaysOffChanged() {
     resetLoads();
     fireResourceChanged();
@@ -124,10 +108,11 @@ public class HumanResource implements CustomPropertyHolder {
     setRole(copy.getRole());
     setStandardPayRate(copy.getStandardPayRate());
     myManager = copy.myManager;
-    DefaultListModel<GanttDaysOff> copyDaysOff = copy.getDaysOff();
-    for (int i = 0; i < copyDaysOff.getSize(); i++) {
-      myDaysOffList.addElement(copyDaysOff.get(i));
-    }
+    // Straight into the list rather than through addDaysOff(): the copy is not in the manager yet
+    // and must not be announced, which is what areEventsEnabled = false above takes care of for the
+    // setters. Adding to the list directly keeps the days off out of it without depending on that
+    // flag at all, and there is no load distribution to reset on a resource being built.
+    myDaysOffList.addAll(copy.getDaysOff());
     areEventsEnabled = true;
     myCustomProperties = copy.myCustomProperties.copyOf();
   }
@@ -217,14 +202,14 @@ public class HumanResource implements CustomPropertyHolder {
 
   public void addDaysOff(GanttDaysOff gdo) {
     System.out.println("add day off: " + gdo.getStart() + " - " + gdo.getFinish() + "");
-    // resetLoads() and fireResourceChanged() are done by the list listener installed above, for
-    // this call and for every other mutation of the list alike.
-    myDaysOffList.addElement(gdo);
+    myDaysOffList.add(gdo);
+    onDaysOffChanged();
   }
 
   /**
-   * Takes a single day off interval away again -- the counterpart of {@link #addDaysOff}, so that a
-   * caller does not have to reach into the list handed out by {@link #getDaysOff} to remove one.
+   * Takes a single day off interval away again -- the counterpart of {@link #addDaysOff}. Together
+   * with {@link #clearDaysOff} it is the only way out, as {@link #getDaysOff} hands out a view that
+   * cannot be modified.
    *
    * The interval is matched the way the list matches it, that is by {@code Object.equals}. Note that
    * GanttDaysOff only overloads {@code equals(GanttDaysOff)} and does not override
@@ -234,9 +219,12 @@ public class HumanResource implements CustomPropertyHolder {
    * @return true if the interval was there and has been removed, false if there was nothing to do
    */
   public boolean removeDaysOff(GanttDaysOff gdo) {
-    // resetLoads() and fireResourceChanged() are done by the list listener installed above, and only
-    // when something really went away: removeElement() stays silent if the interval was not there.
-    return myDaysOffList.removeElement(gdo);
+    if (!myDaysOffList.remove(gdo)) {
+      // Nothing went away, so there is nothing to recalculate and nothing to report.
+      return false;
+    }
+    onDaysOffChanged();
+    return true;
   }
 
   /**
@@ -244,18 +232,28 @@ public class HumanResource implements CustomPropertyHolder {
    * -- the resource properties dialog does not edit single intervals, it drops all of them and
    * writes the edited ones back.
    *
+   * Notifies once when something was removed and not at all when the list was already empty.
+   *
    * Named clearDaysOff rather than plain clear(), unlike HumanResourceManager.clear(), because a
    * resource holds assignments and custom properties too and a bare clear() would not say which of
    * them it means. The ...DaysOff suffix is what the two neighbouring methods already use.
    */
   public void clearDaysOff() {
-    // One notification for the whole removal, and none at all when there was nothing to remove --
-    // see DefaultListModel.clear(). That is exactly what a caller clearing the handed-out list got.
+    if (myDaysOffList.isEmpty()) {
+      // Nothing to remove, so nothing to report. Skipping the empty case is what keeps the cost of
+      // the dialog's clear-all-and-rewrite at (M > 0 ? 1 : 0) + N notifications.
+      return;
+    }
     myDaysOffList.clear();
+    onDaysOffChanged();
   }
 
-  public DefaultListModel<GanttDaysOff> getDaysOff() {
-    return myDaysOffList;
+  /**
+   * @return the resource's days off as an unmodifiable view. Changes go through addDaysOff,
+   *         removeDaysOff and clearDaysOff; the returned list follows them.
+   */
+  public List<GanttDaysOff> getDaysOff() {
+    return myDaysOffView;
   }
 
   public Object getCustomField(CustomPropertyDefinition def) {

--- a/ganttproject/src/main/java/net/sourceforge/ganttproject/resource/HumanResource.java
+++ b/ganttproject/src/main/java/net/sourceforge/ganttproject/resource/HumanResource.java
@@ -222,6 +222,38 @@ public class HumanResource implements CustomPropertyHolder {
     myDaysOffList.addElement(gdo);
   }
 
+  /**
+   * Takes a single day off interval away again -- the counterpart of {@link #addDaysOff}, so that a
+   * caller does not have to reach into the list handed out by {@link #getDaysOff} to remove one.
+   *
+   * The interval is matched the way the list matches it, that is by {@code Object.equals}. Note that
+   * GanttDaysOff only overloads {@code equals(GanttDaysOff)} and does not override
+   * {@code equals(Object)}, so an interval built afresh from the same two dates is NOT the one this
+   * resource holds. Pass an instance obtained from this resource.
+   *
+   * @return true if the interval was there and has been removed, false if there was nothing to do
+   */
+  public boolean removeDaysOff(GanttDaysOff gdo) {
+    // resetLoads() and fireResourceChanged() are done by the list listener installed above, and only
+    // when something really went away: removeElement() stays silent if the interval was not there.
+    return myDaysOffList.removeElement(gdo);
+  }
+
+  /**
+   * Takes every day off interval away in one go. This is what a caller replacing the whole set needs
+   * -- the resource properties dialog does not edit single intervals, it drops all of them and
+   * writes the edited ones back.
+   *
+   * Named clearDaysOff rather than plain clear(), unlike HumanResourceManager.clear(), because a
+   * resource holds assignments and custom properties too and a bare clear() would not say which of
+   * them it means. The ...DaysOff suffix is what the two neighbouring methods already use.
+   */
+  public void clearDaysOff() {
+    // One notification for the whole removal, and none at all when there was nothing to remove --
+    // see DefaultListModel.clear(). That is exactly what a caller clearing the handed-out list got.
+    myDaysOffList.clear();
+  }
+
   public DefaultListModel<GanttDaysOff> getDaysOff() {
     return myDaysOffList;
   }

--- a/ganttproject/src/main/java/net/sourceforge/ganttproject/resource/LoadDistribution.java
+++ b/ganttproject/src/main/java/net/sourceforge/ganttproject/resource/LoadDistribution.java
@@ -9,8 +9,6 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
-import javax.swing.DefaultListModel;
-
 import biz.ganttproject.core.calendar.GanttDaysOff;
 
 import net.sourceforge.ganttproject.task.ResourceAssignment;
@@ -57,10 +55,10 @@ public class LoadDistribution {
   }
 
   private void processDaysOff(HumanResource resource) {
-    DefaultListModel daysOff = resource.getDaysOff();
+    List<GanttDaysOff> daysOff = resource.getDaysOff();
     if (daysOff != null) {
       for (int l = 0; l < daysOff.size(); l++) {
-        GanttDaysOff dayOff = (GanttDaysOff) daysOff.get(l);
+        GanttDaysOff dayOff = daysOff.get(l);
         Date dayOffStart = dayOff.getStart().getTime();
         Date dayOffEnd = dayOff.getFinish().getTime();
         myTasksLoads.add(new Load(dayOffStart, dayOffEnd, -1, null));


### PR DESCRIPTION
### What is wrong

`HumanResource.addDaysOff()` has no counterpart. The only way to take an absence
away is to reach into the `DefaultListModel` that `getDaysOff()` hands out and
mutate it directly, and nothing observes that model. Adding an absence and
removing one are therefore not the same kind of operation: adding resets the
cached `LoadDistribution` and fires `fireResourceChanged()`, removing does
neither.

### Steps to reproduce

1. Create a resource and give it exactly one day off. Press OK.
2. Open the Resources Chart. The absence is drawn as a yellow block.
3. Open the resource again, delete the day off, press OK.

Expected: the block disappears, and anything listening to the resource model is
told that something changed.

Actual: the block stays, and no `resourceChanged` event is fired at all.

### Cause

`GanttDialogPerson.applyChanges()` clears the list before writing the edited
intervals back:

```java
person.getDaysOff().clear();
for (DateInterval interval : myDaysOffModel.getIntervals()) {
  person.addDaysOff(new GanttDaysOff(interval.getStart(), interval.getEnd()));
}
```

With at least one interval left, the last `addDaysOff()` repairs both by
accident. Delete the *last* absence and the loop body never runs, so nothing
calls `resetLoads()` and nothing fires. `resetLoads()` drops the memoised
`myLoadDistribution`, which is the only cache of the computed absences — that is
why the chart keeps drawing the old picture.

That dialog line is the symptom rather than the defect. A fix that only makes
that one line fire leaves the getter handing out an unobserved mutable model,
and the next caller that removes an absence — a batch edit, an importer, a
script — reintroduces the same gap.

### What this changes

**1. `getDaysOff()` hands out an unmodifiable `List` view, and every change goes
through a method.** The field is a plain `ArrayList<GanttDaysOff>` and the getter
returns `Collections.unmodifiableList` over it, typed `List<GanttDaysOff>` —
`DefaultListModel` is a Swing class and models a UI control, not a resource. A
view rather than a copy, so a caller holding on to it keeps seeing the resource.

`addDaysOff()`, `removeDaysOff()` and `clearDaysOff()` each call
`onDaysOffChanged()`, which does `resetLoads()` and `fireResourceChanged()`.
The two halves depend on each other: a plain `List` cannot be observed, so the
notification has to live in the methods, and that is only sound because no
caller can reach past them any more.

`removeDaysOff()` fires only when something was really removed, and
`clearDaysOff()` returns early on an already empty list — what
`DefaultListModel.removeElement()` and `clear()` did by themselves.

The copying constructor fills the list directly with `addAll()` rather than
going through `addDaysOff()`, so copying stays silent without depending on
`areEventsEnabled` for the days off at all.

**2. The two missing counterparts**, in the shape `HumanResourceManager` already
uses for its own list (add / remove / clear):

```java
boolean removeDaysOff(GanttDaysOff gdo)
void clearDaysOff()
```

`removeDaysOff` returns whether anything was removed, which is also the answer to
"did the listeners hear about it" — nothing fires when the interval was not
there. It is `clearDaysOff` rather than a bare `clear()` because a resource holds
assignments and custom properties too.

One caveat, documented on the method and pinned by a test rather than changed
here: `removeDaysOff` matches by `Object.equals`, the way the list matches.
`GanttDaysOff` only overloads `equals(GanttDaysOff)` and does not override
`equals(Object)`, so an interval built afresh from the same two dates is not the
one the resource holds. Callers should pass an instance obtained from the
resource.

`GanttDialogPerson.applyChanges()` now calls `clearDaysOff()` instead of
`getDaysOff().clear()`, and no production code can write to the handed-out list
any more. The readers of `getDaysOff()` move from `getSize()`/`getElementAt(i)`
to `size()`/`get(i)`; `LoadDistribution` and `ProjectFileExporter` were reading
through a raw `DefaultListModel` and lose their casts.

### The number of notifications does not change

Clearing and then writing N intervals back still costs `(M > 0 ? 1 : 0) + N`
`resourceChanged` events, where M is the number of intervals before OK: one event
for the whole removal, none at all when there was nothing to remove. With a plain
`List` that is not free — `List.clear()` has no notion of firing — so
`clearDaysOff()` returns early on an empty list and `removeDaysOff()` returns
`false` without firing when nothing matched. The single event this PR adds is
exactly the one that was missing in the "delete the last absence" case.

### Tests

`HumanResourceDaysOffTest`

* `removing the last day off notifies the listeners just as adding it does`

`HumanResourceRemoveDaysOffTest`

* `removing a single day off takes it off the resource and notifies once`
* `removing a day off the resource does not have changes nothing and notifies nobody`
* `clearing the days off empties the list and notifies once, whatever the count`
* `clearing an empty list of days off notifies nobody`
* `the dialog's clear-all-and-rewrite still costs the same notifications` —
  walks every combination of M and N in `0..3`, pins the absolute event counts
  for `clearDaysOff()` so that an implementation firing once per interval would
  be caught, and pins from the other side that reaching into the handed-out list
  is rejected, removes nothing and notifies nobody.

`HumanResourceDaysOffViewTest`

* `the list handed out by getDaysOff cannot be modified` — `clear`, `add`,
  `removeAt` and `set` on the returned list all throw
  `UnsupportedOperationException`, and the resource is unchanged afterwards.
* `the list handed out by getDaysOff is a view and not a copy` — a day off added
  after the getter call shows up in the list fetched before it.

Without the notification the first test fails with `expected: <1> but was: <0>`,
and without the unmodifiable view the first test of `HumanResourceDaysOffViewTest`
fails with `Expected java.lang.UnsupportedOperationException to be thrown, but
nothing was thrown`. `./gradlew test --continue` is green on the branch: 370 tests
on master, 378 on the branch.

Two existing tests changed with the view: the regression test for the last
absence now removes through `clearDaysOff()` instead of `getDaysOff().clear()`,
and the M/N test turned its "old route" half into the assertion that the old
route is now rejected.