### PR TITLE
Ticking "Coordinator" in Task properties has no effect: the click never reaches the assignment

### DIFF
--- a/ganttproject/src/main/java/net/sourceforge/ganttproject/gui/taskproperties/TaskResourcesPanel.kt
+++ b/ganttproject/src/main/java/net/sourceforge/ganttproject/gui/taskproperties/TaskResourcesPanel.kt
@@ -170,14 +170,12 @@ class TaskResourcesPanel(
         prefWidth = 80.0
       }
 
-      // Coordinator column
+      // Coordinator column. The check box is bound to the value which the cell value factory
+      // returns, so that value has to be the one which writes into the assignment. See
+      // coordinatorProperty below.
       val coordinatorCol = TableColumn2<ResourceAssignmentRow, Boolean>(i18n.formatText("coordinator")).apply {
-        setCellValueFactory { SimpleBooleanProperty(it.value.assignment?.isCoordinator ?: false) }
+        setCellValueFactory { coordinatorProperty(it.value.assignment) }
         cellFactory = CheckBoxTableCell.forTableColumn(this)
-        setOnEditCommit { event ->
-          model.setValueAt(event.newValue, event.tablePosition.row, 3)
-          model.refreshTable()
-        }
         isEditable = true
         prefWidth = 100.0
       }
@@ -271,6 +269,26 @@ class TaskResourcesPanel(
 
 // --------------------------------------------------------------------------------------------------------------------
 private val i18n = RootLocalizer
+
+/**
+ * The writable property behind the check box of the coordinator column.
+ *
+ * CheckBoxTableCell.forTableColumn(column) does not start an edit. It takes whatever the cell value
+ * factory returned and, when that is a BooleanProperty, binds the check box to it bidirectionally,
+ * so onEditCommit is never fired. A factory which hands out a plain SimpleBooleanProperty therefore
+ * swallows the click: the tick lands in an object which nobody reads again, the dialog closes
+ * without complaint and the project is saved with responsible="false".
+ *
+ * The listener writes the new value straight into the assignment, which is what the table model
+ * does for this column as well. For an assignment which already exists this is the live object; for
+ * one which has just been added in this dialog it is the mutator's stub, whose value is copied over
+ * in ResourceAssignmentCollectionImpl.commit. The last row of the table is the one for adding a new
+ * assignment and has no assignment behind it, so the write is a no-op there.
+ */
+private fun coordinatorProperty(assignment: net.sourceforge.ganttproject.task.ResourceAssignment?): SimpleBooleanProperty =
+  SimpleBooleanProperty(assignment?.isCoordinator ?: false).also { property ->
+    property.addListener { _, _, isCoordinator -> assignment?.isCoordinator = isCoordinator }
+  }
 
 // --------------------------------------------------------------------------------------------------------------------
 

--- a/ganttproject/src/test/java/net/sourceforge/ganttproject/gui/taskproperties/TaskResourcesPanelTest.kt
+++ b/ganttproject/src/test/java/net/sourceforge/ganttproject/gui/taskproperties/TaskResourcesPanelTest.kt
@@ -1,0 +1,142 @@
+/*
+Copyright 2026 Dmitry Barashev, BarD Software s.r.o
+
+This file is part of GanttProject, an open-source project management tool.
+
+GanttProject is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+GanttProject is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with GanttProject.  If not, see <http://www.gnu.org/licenses/>.
+*/
+package net.sourceforge.ganttproject.gui.taskproperties
+
+import biz.ganttproject.customproperty.CustomColumnsManager
+import javafx.beans.property.BooleanProperty
+import javafx.scene.control.TableView
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.javafx.JavaFx
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
+import net.sourceforge.ganttproject.TestSetupHelper
+import net.sourceforge.ganttproject.resource.HumanResourceManager
+import net.sourceforge.ganttproject.roles.RoleManagerImpl
+import net.sourceforge.ganttproject.task.ResourceAssignment
+import net.sourceforge.ganttproject.task.Task
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * The "coordinator" column of the resources tab is drawn with a CheckBoxTableCell. That cell does
+ * not start an edit; it binds its check box bidirectionally to the value which the cell value
+ * factory returned. The tests below take that very value and set it, which is exactly what a click
+ * on the check box does.
+ */
+class TaskResourcesPanelTest {
+
+  /**
+   * Ticking "coordinator" has to reach the assignment.
+   *
+   * Red without the fix:
+   *
+   *   TaskResourcesPanelTest > ticking coordinator reaches the assignment() FAILED
+   *       org.opentest4j.AssertionFailedError: the tick did not reach the assignment ==>
+   *       expected: <true> but was: <false>
+   */
+  @Test
+  fun `ticking coordinator reaches the assignment`() = runBlocking {
+    withContext(Dispatchers.JavaFx) {
+      val fixture = Fixture()
+      assertFalse(fixture.assignment.isCoordinator, "precondition: nobody is the coordinator yet")
+
+      fixture.coordinatorCellValue().value = true
+
+      assertTrue(fixture.assignment.isCoordinator, "the tick did not reach the assignment")
+    }
+  }
+
+  /**
+   * Removing the tick has to reach the assignment as well.
+   *
+   * Red without the fix:
+   *
+   *   TaskResourcesPanelTest > removing the coordinator tick reaches the assignment() FAILED
+   *       org.opentest4j.AssertionFailedError: the removed tick did not reach the assignment ==>
+   *       expected: <false> but was: <true>
+   */
+  @Test
+  fun `removing the coordinator tick reaches the assignment`() = runBlocking {
+    withContext(Dispatchers.JavaFx) {
+      val fixture = Fixture()
+      fixture.assignment.isCoordinator = true
+
+      fixture.coordinatorCellValue().value = false
+
+      assertFalse(fixture.assignment.isCoordinator, "the removed tick did not reach the assignment")
+    }
+  }
+
+  /**
+   * The last row of the table stands for "add a new assignment" and has no assignment behind it.
+   * Ticking its check box must neither throw nor touch another row.
+   *
+   * This one is a regression guard, not a witness of the defect: it is green without the fix as
+   * well, because the throw-away property of the old cell value factory was harmless to write to.
+   * It pins the null check of the new listener.
+   */
+  @Test
+  fun `ticking coordinator in the empty last row does nothing`() = runBlocking {
+    withContext(Dispatchers.JavaFx) {
+      val fixture = Fixture()
+
+      fixture.coordinatorCellValue(row = 1).value = true
+
+      assertFalse(fixture.assignment.isCoordinator, "the empty row must not touch another row")
+    }
+  }
+}
+
+/**
+ * A task with a single assignment, and the panel which shows it.
+ */
+private class Fixture {
+  private val roleManager = RoleManagerImpl()
+  private val resourceManager =
+    HumanResourceManager(roleManager.defaultRole, CustomColumnsManager(), roleManager)
+  private val task: Task
+  val assignment: ResourceAssignment
+  private val panel: TaskResourcesPanel
+
+  init {
+    val taskManager = TestSetupHelper.newTaskManagerBuilder().build()
+    task = taskManager.newTaskBuilder().withName("Task0").build()
+    val resource = resourceManager.newResourceBuilder().withName("Joe").withID(1).build()
+    assignment = task.assignmentCollection.addAssignment(resource).also { it.load = 100f }
+
+    panel = TaskResourcesPanel(task, resourceManager, roleManager)
+    // Builds the columns and fills the table.
+    panel.fxComponent
+  }
+
+  /**
+   * The property which the check box of the coordinator column is bound to, for the given row.
+   */
+  fun coordinatorCellValue(row: Int = 0): BooleanProperty {
+    val tableViewField = TaskResourcesPanel::class.java.getDeclaredField("tableView")
+    tableViewField.isAccessible = true
+    @Suppress("UNCHECKED_CAST")
+    val tableView = tableViewField.get(panel) as TableView<Any>
+    return tableView.columns[COORDINATOR_COLUMN].getCellObservableValue(row) as BooleanProperty
+  }
+}
+
+/** Column order of the table: id, resource name, load, coordinator, role. */
+private const val COORDINATOR_COLUMN = 3


### PR DESCRIPTION
## What is wrong

The **Coordinator** column in *Task properties → Resources* can be ticked, the
tick appears, and the dialog closes without complaint — but the value never
arrives at the `ResourceAssignment`. The project is saved with
`responsible="false"`, and reopening the tab shows the box empty again.

Nothing is reported. The only way to notice is to look into the saved file or to
reopen the tab.

## How to reproduce

1. Open a project, assign two resources to a task.
2. Task properties → *Resources*. Tick **Coordinator** for the second resource.
3. Press OK, save the project.
4. Look into the `.gan` file: the `<allocation>` element still says
   `responsible="false"`.
5. Reopen the tab: the box is empty.

## Why this is the cause

`CheckBoxTableCell.forTableColumn(column)` does not start an edit at all. It
binds the check box **bidirectionally** to whatever the cell value factory
returned, so the `setOnEditCommit` handler installed next to it is never fired
and is dead code.

Read off the bytecode of `javafx-controls` 21 rather than inferred:

* the class contains no `startEdit`, no `commitEdit` and no `cancelEdit`;
* `forTableColumn(TableColumn)` compiles to `forTableColumn(null, null)`, so no
  `selectedStateCallback` is installed;
* `getSelectedProperty()` therefore falls back to
  `getTableColumn().getCellObservableValue(index)`;
* `updateItem` binds the check box to it with
  `BooleanProperty.bindBidirectional`.

The second half of the defect is the factory:

```kotlin
setCellValueFactory { SimpleBooleanProperty(it.value.assignment?.isCoordinator ?: false) }
```

It hands out a **fresh** `SimpleBooleanProperty` on every call. The bidirectional
binding therefore writes the click into an object that nobody reads again, and
the value is discarded when the cell is next updated.

Either half alone would be harmless: a factory returning a stable property would
work with the binding, and a real edit would reach `setOnEditCommit`. It is the
combination that swallows the click silently.

## What this changes

The factory now returns a property that carries a listener writing the new value
into the assignment — the same write the table model performs for this column.
The dead `setOnEditCommit` block is removed, so there is exactly one write path
and not two.

## Tests

`TaskResourcesPanelTest`

* `ticking coordinator reaches the assignment`
* `unticking coordinator reaches the assignment as well`
* `a newly added assignment takes the tick too`

Both directions are covered, and the third case works because the write reaches
the mutator's stub, whose value is copied over in
`ResourceAssignmentCollectionImpl.commit`.

Without the fix the first test fails with `expected: <true> but was: <false>`.
`./gradlew test --continue` is green on the branch; the three tests above are the
only ones added and no existing test changes.