### PR TITLE
Write recent colours before <filters> so that no view option is lost

### DIFF
--- a/ganttproject/src/main/java/net/sourceforge/ganttproject/io/ViewSaver.java
+++ b/ganttproject/src/main/java/net/sourceforge/ganttproject/io/ViewSaver.java
@@ -54,8 +54,13 @@ class ViewSaver extends SaverBase {
     writeTimelineTasks(facade, handler);
     new OptionSaver().saveOptionList(handler, facade.getGanttChart().getTaskLabelOptions().getOptions());
     new OptionSaver().saveOptionList(handler, ganttViewProvider.getOptions());
-    writeFilters(handler, taskFilterManager);
+    // The recent colours are written here, before <filters>, so that all <option> elements of this
+    // view form a single uninterrupted run. The reader keeps only the last such run and drops
+    // whatever stands before an element of a different kind without a word. With color.recent
+    // written after <filters> that run consisted of color.recent alone, and the task label options,
+    // the view options and the divider position were lost on the next load.
     writeRecentColors(handler);
+    writeFilters(handler, taskFilterManager);
     endElement("view", handler);
 
     addAttribute("id", "resource-table", attrs);

--- a/ganttproject/src/test/java/net/sourceforge/ganttproject/io/ViewOptionOrderTest.kt
+++ b/ganttproject/src/test/java/net/sourceforge/ganttproject/io/ViewOptionOrderTest.kt
@@ -1,0 +1,170 @@
+/*
+Copyright 2026 BarD Software s.r.o
+
+This file is part of GanttProject, an opensource project management tool.
+
+GanttProject is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+GanttProject is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with GanttProject.  If not, see <http://www.gnu.org/licenses/>.
+*/
+package net.sourceforge.ganttproject.io
+
+import biz.ganttproject.core.io.parseXmlProject
+import biz.ganttproject.core.option.DefaultStringOption
+import biz.ganttproject.core.option.GPOption
+import biz.ganttproject.core.option.GPOptionGroup
+import biz.ganttproject.core.table.ColumnList
+import biz.ganttproject.ganttview.TaskFilterManager
+import net.sourceforge.ganttproject.TestSetupHelper
+import net.sourceforge.ganttproject.chart.GanttChart
+import net.sourceforge.ganttproject.gui.GPColorChooser
+import net.sourceforge.ganttproject.gui.UIFacade
+import net.sourceforge.ganttproject.gui.view.ViewProvider
+import net.sourceforge.ganttproject.gui.zoom.ZoomManager
+import net.sourceforge.ganttproject.storage.ProjectDatabase
+import net.sourceforge.ganttproject.task.TaskView
+import org.easymock.EasyMock.createNiceMock
+import org.easymock.EasyMock.expect
+import org.easymock.EasyMock.replay
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.xml.sax.helpers.AttributesImpl
+import java.awt.Color
+import java.io.ByteArrayOutputStream
+import javax.xml.transform.stream.StreamResult
+
+/**
+ * The `<option>` elements of a `<view>` on their way through a project file: the real ViewSaver
+ * writes them and the real reader reads them back.
+ *
+ * The reader keeps only the last uninterrupted run of `<option>` elements inside a `<view>`.
+ * Everything standing before an element of a different kind is dropped without a word, so the order
+ * in which the saver writes decides how much of a view survives a save and load round trip.
+ */
+class ViewOptionOrderTest : SaverBase() {
+
+  @AfterEach
+  fun tearDown() {
+    GPColorChooser.setRecentColors(mutableListOf())
+  }
+
+  /**
+   * Everything the saver puts into `<view id="gantt-chart">` has to come back when the file is read
+   * again. With `color.recent` written after `<filters>` the recent colours form a run of their own
+   * and every option written before them is lost.
+   */
+  @Test
+  fun `in the order the saver writes today no option is lost`() {
+    GPColorChooser.setRecentColors(mutableListOf(Color.RED))
+    val xml = saveGanttView()
+
+    val ganttView = parseXmlProject(xml).views.first { it.id == "gantt-chart" }
+    val readBack = ganttView.options.orEmpty().map { it.id }
+
+    assertEquals(
+      listOf("taskLabelUp", "taskLabelDown", "divider", "filter.completedTasks", "color.recent"),
+      readBack,
+      "options written into the view did not come back. The document was:\n$xml"
+    )
+  }
+
+  /**
+   * The measurement behind the order above, kept so that the reason for it does not get lost: the
+   * reader keeps only the last uninterrupted run of `<option>` elements. This one exercises the
+   * reader alone and therefore holds whatever order the saver uses.
+   */
+  @Test
+  fun `the reader drops every option that stands before another element`() {
+    val out = ByteArrayOutputStream()
+    val handler = createHandler(StreamResult(out))
+    handler.startDocument()
+    startElement("project", handler)
+    val attrs = AttributesImpl()
+    addAttribute("id", "gantt-chart", attrs)
+    startElement("view", attrs, handler)
+    OptionSaver().saveOptionList(handler, DefaultStringOption("divider", "0.5") as GPOption<*>)
+    startElement("filters", AttributesImpl(), handler)
+    endElement("filters", handler)
+    OptionSaver().saveOptionList(handler, DefaultStringOption("color.recent", "#ff0066") as GPOption<*>)
+    endElement("view", handler)
+    endElement("project", handler)
+    handler.endDocument()
+    val xml = out.toString(Charsets.UTF_8)
+
+    val ganttView = parseXmlProject(xml).views.first { it.id == "gantt-chart" }
+    assertEquals(
+      listOf("color.recent"), ganttView.options.orEmpty().map { it.id },
+      "the reader now keeps options standing before another element; if that is really so, the " +
+        "order in which ViewSaver writes them no longer matters. The document was:\n$xml"
+    )
+  }
+
+  /** Runs the real ViewSaver and returns the document it writes. */
+  private fun saveGanttView(): String {
+    val out = ByteArrayOutputStream()
+    val handler = createHandler(StreamResult(out))
+    handler.startDocument()
+    startElement("project", handler)
+    ViewSaver().save(
+      uiFacade(), ganttViewProvider(), ganttViewProvider(), emptyColumns(), taskFilterManager(),
+      emptyColumns(), handler
+    )
+    endElement("project", handler)
+    handler.endDocument()
+    return out.toString(Charsets.UTF_8)
+  }
+
+  private fun uiFacade(): UIFacade {
+    val zoomState = createNiceMock<ZoomManager.ZoomState>(ZoomManager.ZoomState::class.java)
+    expect(zoomState.persistentName).andStubReturn("default:8")
+    val zoomManager = createNiceMock<ZoomManager>(ZoomManager::class.java)
+    expect(zoomManager.zoomState).andStubReturn(zoomState)
+    val ganttChart = createNiceMock<GanttChart>(GanttChart::class.java)
+    expect(ganttChart.taskLabelOptions).andStubReturn(
+      GPOptionGroup(
+        "taskLabels",
+        DefaultStringOption("taskLabelUp", "name"),
+        DefaultStringOption("taskLabelDown", "duration")
+      )
+    )
+    val facade = createNiceMock<UIFacade>(UIFacade::class.java)
+    expect(facade.zoomManager).andStubReturn(zoomManager)
+    expect(facade.ganttChart).andStubReturn(ganttChart)
+    expect(facade.currentTaskView).andStubReturn(TaskView())
+    replay(zoomState, zoomManager, ganttChart, facade)
+    return facade
+  }
+
+  private fun ganttViewProvider(): ViewProvider {
+    val provider = createNiceMock<ViewProvider>(ViewProvider::class.java)
+    expect(provider.options).andStubReturn(
+      listOf(
+        DefaultStringOption("divider", "0.5"),
+        DefaultStringOption("filter.completedTasks", "false")
+      )
+    )
+    replay(provider)
+    return provider
+  }
+
+  private fun emptyColumns(): ColumnList {
+    val columns = createNiceMock<ColumnList>(ColumnList::class.java)
+    expect(columns.exportData()).andStubReturn(emptyList())
+    replay(columns)
+    return columns
+  }
+
+  private fun taskFilterManager() = TaskFilterManager(
+    TestSetupHelper.newTaskManagerBuilder().build(), createNiceMock<ProjectDatabase>(ProjectDatabase::class.java)
+  )
+}


### PR DESCRIPTION
### What happens

`parseXmlProject` keeps only the **last uninterrupted run** of `<option>` elements
inside a `<view>`. As soon as an element of a different kind — `<filters>` or
`<timeline>` — stands between two runs, everything before it is dropped without a
word. The file on disk still holds every option; the program no longer sees them.

`ViewSaver.save` writes `color.recent` after `writeFilters(...)`. So in any project
that has recent colours the last run consists of that single option, and the up to
nine written before it are gone on the next load: four `taskLabel*`, four
`filter.*`, and `divider`, the position of the splitter between the task table and
the chart. What a user sees is a splitter that keeps jumping back and label
settings that do not stick, with nothing to connect that to recent colours.

The same loss can be seen on the sample project that ships with GanttProject. In
`ganttproject-builder/HouseBuildingSample.gan` the `gantt-chart` view carries six
`<option>` elements with a `<timeline>` standing between them, and exactly one is
read back:

```
<option> elements in the view:   6
view id=gantt-chart read back:   1  ->  [color.recent]
```

(That file was written by an older version, so its element order is not the one the
current saver produces — but it is opened by the current reader, and it loses five
of its six options.)

### The change

`writeRecentColors(handler)` moves before `writeFilters(handler, ...)`. All options
of the view then form a single run and `<filters>` is the last element.

### Why the writing side and not the reader

* It is one line, and no reader has to change.
* Older versions read the new order at least as well as the old one. Since the
  Jackson reader (7767f82fb, 2022-04-01) a single run is exactly the case they
  handle best; before that, `OptionTagHandler` matched every `<option>` by its `id`
  regardless of position, so for those versions the two orders are equivalent.
  Reading the same two documents with the reader built at 08564e556:

```
old order (options, <filters>, color.recent): 1 -> [color.recent]
new order (options, color.recent, <filters>): 5 -> [taskLabelUp, taskLabelDown, divider, filter.completedTasks, color.recent]
```

* Files written by older versions keep losing what they lose: this fixes writing,
  not reading. Whether the reader should also be made tolerant is a separate
  question and is not proposed here.

### Checks

`ViewOptionOrderTest` runs the real `ViewSaver` and reads the document back with
the real reader. Without the change, `in the order the saver writes today no option
is lost` fails with

```
expected: <[taskLabelUp, taskLabelDown, divider, filter.completedTasks, color.recent]>
 but was: <[color.recent]>
```

The second check, `the reader drops every option that stands before another
element`, pins the reader behaviour the order rests on, so the reason for it is not
lost if anyone puts the old order back.

`./gradlew test`: 370 tests before, 372 after, all green.