### PR TITLE
Request the ETag in PROPFIND so that WebDAV writes can be conditional

### DIFF
--- a/ganttproject-tester/test/net/sourceforge/ganttproject/document/webdav/IfMatchResolutionTest.kt
+++ b/ganttproject-tester/test/net/sourceforge/ganttproject/document/webdav/IfMatchResolutionTest.kt
@@ -1,0 +1,135 @@
+/*
+Copyright 2026 BarD Software s.r.o
+
+This file is part of GanttProject, an opensource project management tool.
+
+GanttProject is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+GanttProject is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with GanttProject.  If not, see <http://www.gnu.org/licenses/>.
+*/
+package net.sourceforge.ganttproject.document.webdav
+
+import junit.framework.TestCase
+
+/**
+ * The decision behind conditional writing, checked without a server.
+ *
+ * This covers the rule, not the defect from issue #2818: the rule was never wrong, the ETag simply
+ * never reached it. That the ETag is asked for at all is asserted by
+ * [MiltonResourceEtagTest], and that is the regression test for the issue.
+ *
+ * Both failure directions are covered on purpose. Too weak a condition overwrites somebody else's
+ * work in silence; too strict a one reports a conflict that never happened and teaches the user to
+ * click "overwrite anyway".
+ */
+class IfMatchResolutionTest : TestCase() {
+
+  /** Never asked: the extra request exists for the weak case only. */
+  private val neverAsked: () -> String? = { fail("the server was asked although the tag was strong"); null }
+
+  fun testAStrongTagIsSentAsItIs() {
+    assertEquals(IfMatchDecision.Send("\"abc\""), resolveIfMatch("\"abc\"", neverAsked))
+  }
+
+  /** Nothing known to be conditional on. A first write, and the only case where that is right. */
+  fun testWithoutATagTheWriteIsUnconditional() {
+    assertEquals(IfMatchDecision.Unconditional, resolveIfMatch(null, neverAsked))
+  }
+
+  /**
+   * What Apache produces within a second of a write: the same value, now reported strongly.
+   * Sending the strong form is right, it still identifies our own content.
+   */
+  fun testAWeakTagIsReplacedByTheStrongOneTheServerNowReports() {
+    assertEquals(IfMatchDecision.Send("\"abc\""), resolveIfMatch("W/\"abc\"", currentFromServer = { "\"abc\"" }))
+  }
+
+  /**
+   * Still weak on the first ask, strong on the second: Apache's sub-second mtime window. Waiting
+   * it out and asking again is what keeps ordinary saving working.
+   */
+  fun testStillWeakThenStrongAfterWaiting() {
+    val answers = mutableListOf("W/\"abc\"", "\"abc\"")
+    var paused = 0
+    val decision = resolveIfMatch("W/\"abc\"", { answers.removeAt(0) }, { paused++ })
+    assertEquals(IfMatchDecision.Send("\"abc\""), decision)
+    assertEquals("the second question must come after waiting, not immediately", 1, paused)
+  }
+
+  /**
+   * A server that stays weak gets no write at all, rather than an unconditional one.
+   *
+   * Weakness is not always Apache's mtime window: RFC 9110 requires a weak validator whenever the
+   * representation is transformed in transit - mod_deflate, nginx with gzip, a compressing proxy,
+   * a CDN. Behind any of those it never becomes strong, so a fallback to an unconditional write
+   * would not be a rare concession but every single save, and the protection would be off without
+   * a sign of it.
+   */
+  fun testAServerThatStaysWeakGetsNoWriteAtAll() {
+    assertEquals(
+      IfMatchDecision.VersioningUnavailable,
+      resolveIfMatch("W/\"abc\"", { "W/\"abc\"" }, {})
+    )
+  }
+
+  /** Somebody else wrote while we were waiting out the window. Still a conflict, not a write. */
+  fun testAChangeDuringTheWaitIsAConflict() {
+    val answers = mutableListOf("W/\"abc\"", "\"xyz\"")
+    assertEquals(
+      IfMatchDecision.Conflict,
+      resolveIfMatch("W/\"abc\"", { answers.removeAt(0) }, {})
+    )
+  }
+
+  /** No waiting, and no second question, when the first answer already decides it. */
+  fun testTheServerIsNotAskedTwiceWithoutNeed() {
+    var asked = 0
+    val decision = resolveIfMatch(
+      "W/\"abc\"",
+      { asked++; "\"abc\"" },
+      { fail("waited although the first answer already decided it") }
+    )
+    assertEquals(IfMatchDecision.Send("\"abc\""), decision)
+    assertEquals(1, asked)
+  }
+
+  /** The case the whole mechanism exists for: somebody else wrote in the meantime. */
+  fun testADifferentValueIsAConflict() {
+    assertEquals(IfMatchDecision.Conflict, resolveIfMatch("W/\"abc\"", currentFromServer = { "\"xyz\"" }))
+    assertEquals(IfMatchDecision.Conflict, resolveIfMatch("W/\"abc\"", currentFromServer = { "W/\"xyz\"" }))
+  }
+
+  /**
+   * The server cannot be asked. Send the weak tag anyway and let it refuse: being refused is the
+   * safe direction. A wrong conflict costs a click, a lost change costs work.
+   */
+  fun testWhenTheServerCannotBeAskedTheWeakTagGoesOutAnyway() {
+    assertEquals(IfMatchDecision.Send("W/\"abc\""), resolveIfMatch("W/\"abc\"", currentFromServer = { null }))
+  }
+
+  /**
+   * `W/` is stripped only to recognise one value across a weak/strong change. It must never make
+   * two different tags look equal - that shortcut is what would let a stale write pass.
+   */
+  fun testTheWeaknessMarkerNeverMakesDifferentTagsEqual() {
+    assertEquals("\"abc\"", opaqueEtag("W/\"abc\""))
+    assertEquals("\"abc\"", opaqueEtag("\"abc\""))
+    assertFalse(opaqueEtag("W/\"abc\"") == opaqueEtag("\"abcd\""))
+  }
+
+  fun testWeaknessIsRecognised() {
+    assertTrue(isWeakEtag("W/\"abc\""))
+    assertFalse(isWeakEtag("\"abc\""))
+    // Not a weakness marker: a tag whose content happens to start with W.
+    assertFalse(isWeakEtag("\"W/abc\""))
+  }
+}

--- a/ganttproject-tester/test/net/sourceforge/ganttproject/document/webdav/MiltonResourceEtagTest.java
+++ b/ganttproject-tester/test/net/sourceforge/ganttproject/document/webdav/MiltonResourceEtagTest.java
@@ -1,0 +1,250 @@
+/*
+Copyright 2026 BarD Software s.r.o
+
+This file is part of GanttProject, an opensource project management tool.
+
+GanttProject is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+GanttProject is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with GanttProject.  If not, see <http://www.gnu.org/licenses/>.
+*/
+package net.sourceforge.ganttproject.document.webdav;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import junit.framework.TestCase;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Regression test for issue #2818 -- concurrent WebDAV changes were silently overwritten.
+ *
+ * <p>These tests assert the HTTP conversation, not a decision made inside the client, and that is
+ * the whole point. The defect was in the <em>input</em>: {@code File.getEtag()} always returned
+ * null because Milton's default PROPFIND never asks for {@code getetag}, so every write went out
+ * unconditionally. A test that feeds an ETag to the decision logic and checks the verdict passes
+ * against the broken code as well and proves nothing about this issue.
+ *
+ * <p>The stub server therefore returns {@code getetag} only when the request actually asked for
+ * it, exactly as a real server does. Anything else would hand the client a value it never
+ * requested and hide the very bug under test.
+ */
+public class MiltonResourceEtagTest extends TestCase {
+  private static final String FILE_NAME = "haus.gan";
+  private static final byte[] FILE_CONTENT = "<project/>".getBytes(StandardCharsets.UTF_8);
+  /** Recorded in place of a missing If-Match header, so that "absent" is visible in a diff. */
+  private static final String NO_IF_MATCH = "<no If-Match header>";
+
+  private HttpServer myServer;
+  private MiltonResourceFactory myFactory;
+  private final List<String> myPropFindBodies = Collections.synchronizedList(new ArrayList<String>());
+  private final List<String> myPutIfMatchHeaders = Collections.synchronizedList(new ArrayList<String>());
+  /** The ETag the server currently reports. Changing it stands for somebody else's write. */
+  private volatile String myEtag = "\"v1\"";
+  private volatile int myRefusedPuts = 0;
+  private volatile int myAcceptedPuts = 0;
+
+  @Override
+  protected void setUp() throws Exception {
+    super.setUp();
+    myServer = HttpServer.create(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), 0);
+    myServer.createContext("/", this::handle);
+    myServer.start();
+    myFactory = new MiltonResourceFactory();
+  }
+
+  @Override
+  protected void tearDown() throws Exception {
+    myServer.stop(0);
+    super.tearDown();
+  }
+
+  private MiltonResourceImpl createResource() {
+    String url = "http://127.0.0.1:" + myServer.getAddress().getPort() + "/" + FILE_NAME;
+    return myFactory.createResource(new WebDavUri(url));
+  }
+
+  private static void read(MiltonResourceImpl resource) throws Exception {
+    try (InputStream is = resource.getInputStream()) {
+      ByteArrayOutputStream sink = new ByteArrayOutputStream();
+      byte[] buffer = new byte[512];
+      for (int count = is.read(buffer); count > 0; count = is.read(buffer)) {
+        sink.write(buffer, 0, count);
+      }
+    }
+  }
+
+  private boolean anyPropFindAsksForEtag() {
+    synchronized (myPropFindBodies) {
+      for (String body : myPropFindBodies) {
+        if (body.contains("getetag")) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  /**
+   * THE regression test for #2818: without this request the ETag never arrives and every write is
+   * unconditional, no matter how good the logic downstream of it is.
+   */
+  public void testTheEtagIsRequestedWhenTheFileIsRead() throws Exception {
+    read(createResource());
+    assertTrue(
+        "No PROPFIND asked for DAV:getetag, so the ETag can never arrive and every write stays"
+            + " unconditional. Bodies seen: " + myPropFindBodies,
+        anyPropFindAsksForEtag());
+  }
+
+  /** The remembered ETag has to reach the wire, otherwise the server cannot refuse a stale write. */
+  public void testTheWriteCarriesTheEtagSeenWhenReading() throws Exception {
+    MiltonResourceImpl resource = createResource();
+    read(resource);
+    resource.write(FILE_CONTENT);
+    assertEquals(
+        "The PUT went out without the ETag the read had seen, so the server had nothing to check"
+            + " it against.",
+        Collections.singletonList("\"v1\""),
+        myPutIfMatchHeaders);
+  }
+
+  /**
+   * The symptom from the issue report: somebody else changes the file between read and save. The
+   * save must not go through.
+   */
+  public void testAForeignChangeBetweenReadAndWriteStopsTheWrite() throws Exception {
+    MiltonResourceImpl resource = createResource();
+    read(resource);
+    myEtag = "\"v2\"";
+    try {
+      resource.write(FILE_CONTENT);
+      fail("The write went through although the file had been changed on the server in the"
+          + " meantime. Accepted PUTs: " + myAcceptedPuts + ", If-Match headers: "
+          + myPutIfMatchHeaders);
+    } catch (WebDavResource.WebDavException e) {
+      // The type is checked by name rather than with instanceof on purpose: it keeps this whole
+      // test class compilable against the unfixed code, so that reverting the fix produces
+      // honest test failures instead of a compile error.
+      assertEquals("A 412 was reported as a transport error, so the caller cannot tell a genuine"
+              + " conflict from a broken connection.",
+          "WebDavConflictException", e.getClass().getSimpleName());
+    }
+    assertEquals("The server did not refuse anything, so the PUT cannot have been conditional.",
+        1, myRefusedPuts);
+    assertEquals("Somebody else's version was overwritten -- this is the defect from #2818.",
+        0, myAcceptedPuts);
+  }
+
+  // ---------------------------------------------------------------- the stub server
+
+  private void handle(HttpExchange exchange) throws IOException {
+    try {
+      String method = exchange.getRequestMethod();
+      String path = exchange.getRequestURI().getPath();
+      String body = new String(readAll(exchange.getRequestBody()), StandardCharsets.UTF_8);
+      if ("PROPFIND".equals(method)) {
+        myPropFindBodies.add(body);
+        String depth = exchange.getRequestHeaders().getFirst("Depth");
+        // A real server answers with the properties that were asked for, and with those only.
+        boolean withEtag = body.contains("getetag") || body.contains("allprop");
+        respondMultistatus(exchange, path, !"0".equals(depth), withEtag);
+      } else if ("GET".equals(method)) {
+        exchange.getResponseHeaders().add("ETag", myEtag);
+        respond(exchange, 200, FILE_CONTENT);
+      } else if ("PUT".equals(method)) {
+        String ifMatch = exchange.getRequestHeaders().getFirst("If-Match");
+        myPutIfMatchHeaders.add(ifMatch == null ? NO_IF_MATCH : ifMatch);
+        if (ifMatch != null && !ifMatch.equals(myEtag)) {
+          myRefusedPuts++;
+          respond(exchange, 412, new byte[0]);
+        } else {
+          myAcceptedPuts++;
+          myEtag = "\"v-after-put\"";
+          respond(exchange, 204, new byte[0]);
+        }
+      } else if ("OPTIONS".equals(method) || "HEAD".equals(method)) {
+        exchange.getResponseHeaders().add("DAV", "1,2");
+        exchange.getResponseHeaders().add("Allow", "OPTIONS, GET, HEAD, PUT, PROPFIND");
+        respond(exchange, 200, new byte[0]);
+      } else {
+        respond(exchange, 405, new byte[0]);
+      }
+    } finally {
+      exchange.close();
+    }
+  }
+
+  private void respondMultistatus(HttpExchange exchange, String path, boolean deep, boolean withEtag)
+      throws IOException {
+    StringBuilder xml = new StringBuilder();
+    xml.append("<?xml version=\"1.0\" encoding=\"utf-8\"?>");
+    xml.append("<D:multistatus xmlns:D=\"DAV:\">");
+    if ("/".equals(path)) {
+      appendCollection(xml);
+      if (deep) {
+        appendFile(xml, withEtag);
+      }
+    } else {
+      appendFile(xml, withEtag);
+    }
+    xml.append("</D:multistatus>");
+    exchange.getResponseHeaders().add("Content-Type", "text/xml; charset=\"utf-8\"");
+    respond(exchange, 207, xml.toString().getBytes(StandardCharsets.UTF_8));
+  }
+
+  private static void appendCollection(StringBuilder xml) {
+    xml.append("<D:response><D:href>/</D:href><D:propstat><D:prop>");
+    xml.append("<D:displayname>root</D:displayname>");
+    xml.append("<D:getlastmodified>Wed, 02 Sep 2026 10:00:00 GMT</D:getlastmodified>");
+    xml.append("<D:resourcetype><D:collection/></D:resourcetype>");
+    xml.append("</D:prop><D:status>HTTP/1.1 200 OK</D:status></D:propstat></D:response>");
+  }
+
+  private void appendFile(StringBuilder xml, boolean withEtag) {
+    xml.append("<D:response><D:href>/").append(FILE_NAME).append("</D:href><D:propstat><D:prop>");
+    xml.append("<D:displayname>").append(FILE_NAME).append("</D:displayname>");
+    xml.append("<D:getcontentlength>").append(FILE_CONTENT.length).append("</D:getcontentlength>");
+    xml.append("<D:getcontenttype>application/xml</D:getcontenttype>");
+    xml.append("<D:getlastmodified>Wed, 02 Sep 2026 10:00:00 GMT</D:getlastmodified>");
+    xml.append("<D:resourcetype/>");
+    if (withEtag) {
+      xml.append("<D:getetag>").append(myEtag).append("</D:getetag>");
+    }
+    xml.append("</D:prop><D:status>HTTP/1.1 200 OK</D:status></D:propstat></D:response>");
+  }
+
+  private static void respond(HttpExchange exchange, int code, byte[] content) throws IOException {
+    if (content.length == 0) {
+      exchange.sendResponseHeaders(code, -1);
+    } else {
+      exchange.sendResponseHeaders(code, content.length);
+      exchange.getResponseBody().write(content);
+    }
+  }
+
+  private static byte[] readAll(InputStream is) throws IOException {
+    ByteArrayOutputStream sink = new ByteArrayOutputStream();
+    byte[] buffer = new byte[512];
+    for (int count = is.read(buffer); count > 0; count = is.read(buffer)) {
+      sink.write(buffer, 0, count);
+    }
+    return sink.toByteArray();
+  }
+}

--- a/ganttproject/src/main/java/net/sourceforge/ganttproject/document/webdav/IfMatchResolution.kt
+++ b/ganttproject/src/main/java/net/sourceforge/ganttproject/document/webdav/IfMatchResolution.kt
@@ -1,0 +1,117 @@
+/*
+Copyright 2026 BarD Software s.r.o
+
+This file is part of GanttProject, an opensource project management tool.
+
+GanttProject is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+GanttProject is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with GanttProject.  If not, see <http://www.gnu.org/licenses/>.
+*/
+package net.sourceforge.ganttproject.document.webdav
+
+/**
+ * Which ETag, if any, a write should carry in `If-Match`.
+ *
+ * Kept apart from the WebDAV plumbing so that it can be decided, and tested, without a server.
+ * Both ways of getting it wrong are silent: too weak a condition overwrites a colleague's work,
+ * too strict a one reports a conflict that never happened and teaches the user to click
+ * "overwrite anyway".
+ */
+sealed interface IfMatchDecision {
+  /** Send this ETag in `If-Match`. */
+  data class Send(val etag: String) : IfMatchDecision
+
+  /**
+   * Write without a condition. Reached only when nothing is remembered - a first write, or a read
+   * whose version the server would not tell us. There is no version to be conditional on.
+   */
+  data object Unconditional : IfMatchDecision
+
+  /** Somebody else changed the file. Do not write. */
+  data object Conflict : IfMatchDecision
+
+  /**
+   * The server never answers with a strong ETag, so no write can be made conditional.
+   *
+   * Refusing rather than falling back to an unconditional write: RFC 9110 requires a weak
+   * validator whenever the representation is transformed in transit - `mod_deflate`, nginx with
+   * `gzip`, a compressing proxy, a CDN. Behind any of those the tag never becomes strong, so a
+   * fallback would not be a rare concession but every single save, and conditional writing would
+   * be switched off permanently without a sign of it.
+   */
+  data object VersioningUnavailable : IfMatchDecision
+}
+
+/** `W/"abc"` is weak, `"abc"` is strong. */
+fun isWeakEtag(etag: String): Boolean = etag.trimStart().startsWith("W/")
+
+/**
+ * The tag without its weakness marker, for recognising one value across a weak/strong change.
+ *
+ * Not a general ETag comparison: dropping `W/` and treating the rest as equal is exactly the
+ * shortcut that would let a stale write through. Used only against a value the server just
+ * reported, to tell "our own file, freshly written" from "somebody else's".
+ */
+fun opaqueEtag(etag: String): String = etag.trim().removePrefix("W/").trim()
+
+/** How long to wait out Apache's sub-second mtime window before asking a second time. */
+const val WEAK_ETAG_RETRY_MILLIS = 1100L
+
+/**
+ * Decides the `If-Match` value for a write.
+ *
+ * Apache with `mod_dav_fs` returns no ETag on `PUT`, and for about a second after a write it
+ * reports the ETag as weak, afterwards the same value as strong. `If-Match` is compared strongly
+ * (RFC 9110), so a weak tag matches nothing at all, not even itself. Sending a freshly fetched
+ * weak tag straight back would therefore produce a 412 on every save and show the user a conflict
+ * that never happened. Hence the second question after a pause: it separates that window, which
+ * passes, from a permanently weak validator, which does not.
+ *
+ * @param remembered the ETag the pending changes are based on, or null when none is known.
+ * @param currentFromServer asks the server for the ETag the file carries right now; null when the
+ * question cannot be answered. Consulted only when [remembered] is weak.
+ * @param pause waits between the two questions. A parameter so that tests need not really sleep.
+ */
+// @JvmOverloads: the caller is Java and would not otherwise see Kotlin's default argument.
+@JvmOverloads
+fun resolveIfMatch(
+  remembered: String?,
+  currentFromServer: () -> String?,
+  pause: () -> Unit = { Thread.sleep(WEAK_ETAG_RETRY_MILLIS) }
+): IfMatchDecision {
+  if (remembered == null) return IfMatchDecision.Unconditional
+  if (!isWeakEtag(remembered)) return IfMatchDecision.Send(remembered)
+
+  when (val first = judge(remembered, currentFromServer())) {
+    is Judged.Decided -> return first.decision
+    Judged.StillWeak -> {}
+  }
+
+  pause()
+  return when (val second = judge(remembered, currentFromServer())) {
+    is Judged.Decided -> second.decision
+    Judged.StillWeak -> IfMatchDecision.VersioningUnavailable
+  }
+}
+
+private sealed interface Judged {
+  data class Decided(val decision: IfMatchDecision) : Judged
+  data object StillWeak : Judged
+}
+
+private fun judge(remembered: String, current: String?): Judged {
+  // Cannot ask: send the weak tag and let the server refuse it. Being refused is the safe
+  // direction, writing blind is not.
+  if (current == null) return Judged.Decided(IfMatchDecision.Send(remembered))
+  if (opaqueEtag(current) != opaqueEtag(remembered)) return Judged.Decided(IfMatchDecision.Conflict)
+  return if (isWeakEtag(current)) Judged.StillWeak else Judged.Decided(IfMatchDecision.Send(current))
+}

--- a/ganttproject/src/main/java/net/sourceforge/ganttproject/document/webdav/MiltonResourceImpl.java
+++ b/ganttproject/src/main/java/net/sourceforge/ganttproject/document/webdav/MiltonResourceImpl.java
@@ -32,8 +32,10 @@ import io.milton.httpclient.Host;
 import io.milton.httpclient.HttpException;
 import io.milton.httpclient.IfMatchCheck;
 import io.milton.httpclient.ProgressListener;
+import io.milton.httpclient.PropFindResponse;
 import io.milton.httpclient.Resource;
 import io.milton.httpclient.Utils.CancelledException;
+import net.sourceforge.ganttproject.GPLogger;
 
 import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
@@ -45,6 +47,8 @@ import java.text.MessageFormat;
 import java.util.Collections;
 import java.util.List;
 
+import javax.xml.namespace.QName;
+
 /**
  * Implementation which uses Milton client library.
  *
@@ -52,7 +56,24 @@ import java.util.List;
  */
 public class MiltonResourceImpl implements WebDavResource {
   private static final ProgressListener PROGRESS_LISTENER_STUB = null;
+
+  /**
+   * The ETag has to be asked for by name.
+   *
+   * Milton's default PROPFIND requests DAV:etag, which is not a WebDAV property at all - RFC 4918
+   * calls it DAV:getetag - while PropFindResponse#getEtag() reads DAV:getetag. The two never meet,
+   * so getEtag() returned null whatever the server sent, and every write went out unconditionally.
+   */
+  private static final QName ETAG_PROPERTY = new QName("DAV:", "getetag");
+
   private Resource myImpl;
+
+  /**
+   * The ETag the resource carried when it was read: the version the pending changes are based on.
+   * Null until something has been read.
+   */
+  private String myEtagAtRead;
+
   private final WebDavUri myUrl;
   private final Host myHost;
   private Boolean myExistance;
@@ -269,6 +290,28 @@ public class MiltonResourceImpl implements WebDavResource {
     return Path.path(myUrl.path).getName();
   }
 
+  /**
+   * Asks the server for the ETag which the resource carries right now.
+   *
+   * A request of its own rather than {@code myImpl.getEtag()}: the cached resource carries the
+   * value from the last listing, and that is precisely not the question here.
+   *
+   * Returns null when the question cannot be answered. The callers handle "do not know"
+   * explicitly, and an invented version would be worse than none.
+   */
+  private String fetchCurrentEtag() {
+    try {
+      List<PropFindResponse> responses =
+          getHost().propFind(Path.path(myUrl.path), 0, Collections.singletonList(ETAG_PROPERTY));
+      return (responses == null || responses.isEmpty()) ? null : responses.get(0).getEtag();
+    } catch (Exception e) {
+      // RuntimeException included: this is an extra question and must never be the reason why
+      // opening or saving fails.
+      GPLogger.log(e);
+      return null;
+    }
+  }
+
   @Override
   public void write(byte[] byteArray) throws WebDavException {
     MiltonResourceImpl parent = (MiltonResourceImpl) getParent();
@@ -280,16 +323,50 @@ public class MiltonResourceImpl implements WebDavResource {
     try {
       InputStream is = new BufferedInputStream(new ByteArrayInputStream(byteArray));
       if (myImpl != null && myImpl.getLockToken() != null) {
+        // The lock token goes out in the If: header. IfMatchCheck carries exactly one string, so
+        // a token and an ETag cannot be sent together; If-Match is needed precisely when no token
+        // is held.
         parentFolder.upload(getName(), is, Long.valueOf(byteArray.length),
             "application/xml", new IfMatchCheck(myImpl.getLockToken(), false, true), null);
       } else {
-        parentFolder.upload(getName(), is, Long.valueOf(byteArray.length), null);
+        IfMatchDecision decision =
+            IfMatchResolutionKt.resolveIfMatch(myEtagAtRead, this::fetchCurrentEtag);
+        if (decision instanceof IfMatchDecision.Conflict) {
+          throw new WebDavConflictException(MessageFormat.format(
+              "File {0} has been changed by somebody else since it was read", myUrl.path));
+        }
+        if (decision instanceof IfMatchDecision.VersioningUnavailable) {
+          // Refusing rather than writing blind. A fallback to an unconditional write would fire on
+          // every save behind a compressing proxy or a CDN, and the protection would be off
+          // without a sign of it.
+          throw new WebDavVersioningUnavailableException(MessageFormat.format(
+              "Only weak ETags are reported for {0}, so this write cannot be made conditional",
+              myUrl.path));
+        }
+        if (decision instanceof IfMatchDecision.Send) {
+          parentFolder.upload(getName(), is, Long.valueOf(byteArray.length), "application/xml",
+              new IfMatchCheck(((IfMatchDecision.Send) decision).getEtag(), true, false), null);
+        } else {
+          // Nothing remembered: a first write, with no version to be conditional on.
+          parentFolder.upload(getName(), is, Long.valueOf(byteArray.length), null);
+        }
       }
+      // Apache returns no ETag on PUT, so the new version has to be asked for. If that fails the
+      // value stays null: writing unconditionally next time is better than remembering a version
+      // against which every later comparison would fail.
+      myEtagAtRead = fetchCurrentEtag();
     } catch (NotAuthorizedException e) {
       throw new WebDavException(MessageFormat.format("User {0} is probably not authorized to access {1}", getUsername(), myUrl.hostName), e);
     } catch (BadRequestException e) {
       throw new WebDavException(MessageFormat.format("Bad request when accessing {0}", myUrl.hostName), e);
     } catch (HttpException e) {
+      // 412 is not a transport problem but the server's answer to If-Match: the file changed since
+      // it was read. Milton maps it to GenericHttpException, since processResultCode only
+      // special-cases 400/401/404/409, so the status has to be read off the exception.
+      if (e.getResult() == 412) {
+        throw new WebDavConflictException(MessageFormat.format(
+            "File {0} has been changed by somebody else since it was read", myUrl.path), e);
+      }
       throw new WebDavException(MessageFormat.format("HTTP problems when accessing {0}", myUrl.hostName), e);
     } catch (ConflictException e) {
       throw new WebDavException(MessageFormat.format("Conflict when accessing {0}", myUrl.hostName), e);
@@ -309,6 +386,17 @@ public class MiltonResourceImpl implements WebDavResource {
     File file = (File) myImpl;
     ByteArrayOutputStream content = new ByteArrayOutputStream();
     try {
+      // Remember the version the coming changes are based on, and deliberately before the
+      // download. If the file changes in between, the remembered ETag is older than the content
+      // that was read and saving reports a conflict which strictly speaking is not one. The other
+      // order - ETag newer than content - would silently overwrite somebody else's change. Of the
+      // two errors, the superfluous question is the harmless one.
+      myEtagAtRead = fetchCurrentEtag();
+      if (myEtagAtRead == null) {
+        GPLogger.log(MessageFormat.format(
+            "No ETag for {0}; the server cannot be asked to refuse a write over a concurrent"
+                + " change", myUrl.path));
+      }
       file.download(content, PROGRESS_LISTENER_STUB);
       return new ByteArrayInputStream(content.toByteArray());
     } catch (CancelledException e) {

--- a/ganttproject/src/main/java/net/sourceforge/ganttproject/document/webdav/WebDavResource.java
+++ b/ganttproject/src/main/java/net/sourceforge/ganttproject/document/webdav/WebDavResource.java
@@ -38,6 +38,35 @@ public interface WebDavResource {
       super(message, cause);
     }
   }
+
+  /**
+   * Somebody else changed the resource since it was read, and the conditional write was refused.
+   *
+   * A type of its own rather than a plain {@link WebDavException} because the caller has to react
+   * differently: nothing is broken and retrying will not help, there is simply a second version.
+   */
+  class WebDavConflictException extends WebDavException {
+    public WebDavConflictException(String message) {
+      super(message);
+    }
+    public WebDavConflictException(String message, Throwable cause) {
+      super(message, cause);
+    }
+  }
+
+  /**
+   * The server cannot answer a version check because it only ever reports weak ETags, and no
+   * If-Match can be built from a weak validator.
+   *
+   * Distinct from {@link WebDavConflictException} because the cause is unrelated: in a conflict
+   * somebody changed the file, here nobody did anything and the question is merely unanswerable.
+   */
+  class WebDavVersioningUnavailableException extends WebDavException {
+    public WebDavVersioningUnavailableException(String message) {
+      super(message);
+    }
+  }
+
   class WebDavRuntimeException extends RuntimeException {
     public WebDavRuntimeException(String message) {
       super(message);


### PR DESCRIPTION
Concurrent changes on a WebDAV server are silently overwritten today: whoever saves last wins, and no conflict is ever reported.

## Cause

`MiltonResourceImpl` relies on `File.getEtag()`. Milton's default PROPFIND asks for

```
DAV:{resourcetype, etag, displayname, getcontentlength, creationdate,
     getlastmodified, iscollection, lockdiscovery, supportedlock}
```

but `PropFindResponse.getEtag()` reads `DAV:getetag`. `DAV:etag` is not a WebDAV property at all — RFC 4918 defines `getetag` — so the requested name and the read name never meet and `getEtag()` returns `null` whatever the server sends. `write()` then takes the unconditional overload:

```java
parentFolder.upload(getName(), is, Long.valueOf(byteArray.length), null);
```

No `If-Match`, no `If-None-Match`, no lock token.

## Fix

* Ask for `DAV:getetag` explicitly in a PROPFIND of its own.
* Remember the ETag seen when the file was read — that is the version the pending changes are based on — and send it as `If-Match` on write.
* Map HTTP 412 to a conflict rather than a transport error. Milton reports it as a `GenericHttpException`, because `processResultCode` only special-cases 400/401/404/409, so the status is read off `getResult()`.

The decision of *which* ETag to send is separated into `IfMatchResolution.kt` so it can be tested without a server. It exists because of one awkward server behaviour: Apache with `mod_dav_fs` returns no ETag on `PUT`, and for about a second after a write it reports the ETag as weak, afterwards the same value as strong. `If-Match` is compared strongly (RFC 9110), so a weak tag matches nothing — not even itself. Sending a freshly fetched weak tag straight back would produce a 412 on every save and show a conflict that never happened.

Two decisions worth calling out, since both are easy to get wrong in the other direction:

**A server that only ever reports weak ETags gets no write at all**, rather than a fallback to an unconditional upload. RFC 9110 *requires* a weak validator whenever the representation is transformed in transit — `mod_deflate`, nginx with `gzip`, a compressing proxy, a CDN. Behind any of those the tag never becomes strong, so the fallback would not be a rare concession but every single save, and the protection would be off permanently and without a sign of it.

**With a lock held, the lock token goes out in the `If:` header as before.** `IfMatchCheck` carries exactly one string, so a token and an ETag cannot be sent together; `If-Match` is needed precisely when no token is held — which today is always, since `acquireLock()` has no caller anywhere in the codebase. That is a separate defect and is not touched here.

## Tests

`MiltonResourceEtagTest` is the regression test for this issue. It drives a stub WebDAV server (`com.sun.net.httpserver`, JDK only, no new dependency) which records every PROPFIND body and every `If-Match` header, and — like a real server — returns only the properties that were asked for. It asserts that:

1. a PROPFIND for `getetag` is actually issued when the file is read;
2. the PUT carries the ETag that the read had seen;
3. a foreign change between read and write stops the write, with the server refusing via 412.

All three fail against the unfixed code, with the third reporting `Accepted PUTs: 1` — the defect itself. The test class deliberately still *compiles* against the unfixed code, so reverting the fix produces honest failures rather than a compile error; that is why it checks the exception type by name rather than with `instanceof`.

`IfMatchResolutionTest` covers the decision rule — remembered versus current ETag giving send, conflict, unconditional or unavailable, plus the weak-tag retry. It is not a regression test for this issue: the rule was never wrong, the ETag simply never reached it. It is included because this PR introduces `IfMatchResolution.kt`, and the weak-ETag paths (the retry, the pause, the permanently weak server) are impractical to reach through HTTP without making every test sleep.

Full suite: 375 tests before, 389 after, 0 failures.

Fixes #2818