### PR TITLE
Let the status bar items take the width of their content

### DIFF
--- a/ganttproject/src/main/sass/biz/ganttproject/app/StatusBar.scss
+++ b/ganttproject/src/main/sass/biz/ganttproject/app/StatusBar.scss
@@ -24,7 +24,6 @@
   -fx-text-fill: $gp-dark-gray;
   -fx-padding: 1ex 24px;
   -fx-alignment: center-left;
-  -fx-min-width: 50em;
   &.align_right {
     -fx-alignment: center-right;
   }

--- a/ganttproject/src/test/java/biz/ganttproject/app/StatusBarWidthTest.kt
+++ b/ganttproject/src/test/java/biz/ganttproject/app/StatusBarWidthTest.kt
@@ -1,0 +1,116 @@
+/*
+Copyright 2026 BarD Software s.r.o
+
+This file is part of GanttProject, an open-source project management tool.
+
+GanttProject is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+GanttProject is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with GanttProject.  If not, see <http://www.gnu.org/licenses/>.
+*/
+package biz.ganttproject.app
+
+import javafx.scene.Scene
+import javafx.scene.control.Button
+import javafx.scene.control.Label
+import javafx.scene.layout.HBox
+import javafx.scene.layout.Pane
+import javafx.scene.layout.Priority
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.javafx.JavaFx
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * The status bar is a horizontal box that holds the cloud indicator on the left, the notification
+ * buttons on the right and a growing pane in between. Both indicators carry the .statusbar style
+ * class, so whatever width that class claims is claimed twice, and the growing pane is left with
+ * what remains.
+ */
+class StatusBarWidthTest {
+  /** The width of the smallest window GanttProject is expected to work in. */
+  private val windowWidth = 1024.0
+  private val barHeight = 32.0
+  /** The left and right padding of a status bar item, from StatusBar.css. */
+  private val itemPadding = 24.0
+
+  private fun statusBarItem(child: javafx.scene.Node, vararg styles: String) =
+    HBox(child).also {
+      it.stylesheets.add("biz/ganttproject/app/StatusBar.css")
+      it.styleClass.add("statusbar")
+      it.styleClass.addAll(*styles)
+    }
+
+  private fun layOut(root: Pane, width: Double = windowWidth) {
+    Scene(root, width, barHeight)
+    root.resize(width, barHeight)
+    root.applyCss()
+    root.layout()
+  }
+
+  @Test
+  fun `the space between the status bar items can be used`() = runBlocking {
+    withContext(Dispatchers.JavaFx) {
+      val cloudIndicator = statusBarItem(Label("Cloud: disconnected"))
+      val notifications = statusBarItem(Button("Errors"), "align_right", "notifications")
+      val filler = Pane()
+      val bar = HBox(cloudIndicator, filler, notifications)
+      HBox.setHgrow(filler, Priority.ALWAYS)
+      layOut(bar)
+
+      assertTrue(
+        filler.width > windowWidth / 2,
+        "the two status bar items leave only ${filler.width} px of the $windowWidth px window " +
+          "for what is put between them: the cloud indicator takes ${cloudIndicator.width} px and " +
+          "the notification buttons take ${notifications.width} px"
+      )
+    }
+  }
+
+  @Test
+  fun `the notification buttons stay inside the window`() = runBlocking {
+    withContext(Dispatchers.JavaFx) {
+      val button = Button("Errors")
+      val notifications = statusBarItem(button, "align_right", "notifications")
+      val filler = Pane()
+      val bar = HBox(statusBarItem(Label("Cloud: disconnected")), filler, notifications)
+      HBox.setHgrow(filler, Priority.ALWAYS)
+      layOut(bar)
+
+      assertEquals(
+        windowWidth - itemPadding, button.localToScene(button.boundsInLocal).maxX, 0.5,
+        "the notification buttons do not end at the right edge of the window"
+      )
+    }
+  }
+
+  @Test
+  fun `a single status bar item keeps the place it had`() = runBlocking {
+    withContext(Dispatchers.JavaFx) {
+      val label = Label("Cloud: disconnected")
+      val cloudIndicator = statusBarItem(label)
+      layOut(HBox(cloudIndicator))
+
+      assertEquals(
+        itemPadding, label.localToScene(label.boundsInLocal).minX, 0.5,
+        "the text of the cloud indicator no longer starts behind the padding of its item"
+      )
+      assertTrue(
+        label.width >= label.prefWidth(-1.0),
+        "the cloud indicator is given ${label.width} px for a text that asks for " +
+          "${label.prefWidth(-1.0)} px, so it is cut short"
+      )
+    }
+  }
+}


### PR DESCRIPTION
The status bar is a horizontal box holding the cloud indicator on the left, the notification buttons on the right and a growing pane in between. Both indicators carry the .statusbar style class, which claimed a minimum width of 50em. At the default font size of 13px that is 650px per item, so 1300px were reserved before anything between them got a single pixel.

On a 1024px window the growing pane was therefore left with 0px and the notification buttons were pushed out of the window altogether: on a 1024x768 screen the status bar ended at x=210 and neither the news button nor the error button was visible at all.

The reservation was not earned. The cloud indicator ended at x=651 while its text "Cloud: disconnected" already ended at x=260, so 391px of the item were enforced empty space. Dropping the minimum lets both items size to their content. Their padding and alignment are untouched, so a single item stays exactly where it was: a screenshot of the left half of the status bar before and after is identical to the pixel, and the notification buttons now end at the right edge of the window.
`StatusBarWidthTest` lays out the same box `GanttProjectFxApp` builds and checks
three things: that the space between the items can be used, that the
notification buttons stay inside the window, and — as a guard — that a single
item keeps the place it had. The first two fail against the unfixed stylesheet.
Whole suite: 375 tests before, 382 after, 0 failures.