### PR TITLE
Bound the size of an alert that carries a formatted message

### DIFF
--- a/ganttproject/src/main/java/net/sourceforge/ganttproject/UIFacadeImpl.java
+++ b/ganttproject/src/main/java/net/sourceforge/ganttproject/UIFacadeImpl.java
@@ -33,9 +33,12 @@ import com.google.common.collect.Maps;
 import com.sandec.mdfx.MarkdownView;
 import com.vladsch.flexmark.html2md.converter.FlexmarkHtmlConverter;
 import com.vladsch.flexmark.util.data.MutableDataSet;
+import javafx.scene.Node;
 import javafx.scene.control.Alert;
 import javafx.scene.control.ButtonType;
+import javafx.scene.control.ScrollPane;
 import javafx.stage.Modality;
+import javafx.stage.Screen;
 import javafx.stage.Stage;
 import javafx.stage.StageStyle;
 import kotlin.Unit;
@@ -300,13 +303,10 @@ class UIFacadeImpl extends ProgressProvider implements UIFacade {
 
       alert.initOwner(myWindow);
       if ((messageType & HTML_MESSAGE_FORMAT) != 0) {
-        alert.getDialogPane().setContent(new MarkdownView("""
-          %s
-          """.formatted(FlexmarkHtmlConverter.builder(new MutableDataSet()).build().convert(message))));
+        alert.getDialogPane().setContent(createFormattedContent(
+            FlexmarkHtmlConverter.builder(new MutableDataSet()).build().convert(message)));
       } else if ((messageType & MARKDOWN_MESSAGE_FORMAT) != 0) {
-        alert.getDialogPane().setContent(new MarkdownView("""
-          %s
-          """.formatted(message)));
+        alert.getDialogPane().setContent(createFormattedContent(message));
       } else {
         alert.setContentText(message);
       }
@@ -336,6 +336,71 @@ class UIFacadeImpl extends ProgressProvider implements UIFacade {
     });
   }
 
+  /**
+   * The widest column a formatted message is laid out in. Twice the 360px that
+   * DialogPane.createContentLabel gives a plain text message, because a formatted one may carry
+   * tables and code blocks that do not wrap. It is a fixed number rather than a share of the
+   * screen: how wide a column may be before it becomes hard to read does not depend on the monitor.
+   */
+  private static final double MAX_CONTENT_WIDTH = 720;
+  /**
+   * The share of the screen height a message may fill before it starts to scroll. This one does
+   * depend on the monitor: what is left has to hold the header and the buttons.
+   */
+  private static final double MAX_CONTENT_HEIGHT_RATIO = 0.6;
+
+  /**
+   * Wraps a Markdown message into a node that a dialog can show without growing out of the screen.
+   *
+   * <p>A MarkdownView is a VBox and asks for as much width as its longest paragraph needs, and
+   * DialogPane takes the preferred size of its content as its own. A long message therefore made
+   * the dialog as wide as the screen and taller than the screen, which pushed the buttons out of
+   * the window: the dialog could then only be closed with Escape. The scroll pane bounds both
+   * directions and makes the part that does not fit reachable.
+   *
+   * <p>The bounds are put on the preferred size and not on the maximum, because the preferred size
+   * is the only one DialogPane asks the content for.
+   */
+  static Node createFormattedContent(String markdown) {
+    var view = new MarkdownView("""
+      %s
+      """.formatted(markdown));
+    var maxHeight = Screen.getPrimary().getVisualBounds().getHeight() * MAX_CONTENT_HEIGHT_RATIO;
+    var scroll = new ScrollPane(view) {
+      @Override
+      protected double computePrefWidth(double height) {
+        return Math.min(super.computePrefWidth(height), MAX_CONTENT_WIDTH);
+      }
+
+      @Override
+      protected double computePrefHeight(double width) {
+        // Asking the view how tall it is at the width it asked for would be the wrong question:
+        // once the message is wider than the bound it is laid out in a narrower column and wraps
+        // into more lines than it planned for.
+        var insets = getInsets();
+        var columnWidth = computePrefWidth(-1) - insets.getLeft() - insets.getRight();
+        return Math.min(
+            view.prefHeight(columnWidth) + insets.getTop() + insets.getBottom(), maxHeight);
+      }
+    };
+    // Let the text wrap to the viewport width. Not fitToHeight, which would stretch the content to
+    // the viewport and so defeat the scrolling.
+    scroll.setFitToWidth(true);
+    // A scroll pane brings a border and a background of its own from modena.css, which would draw
+    // a box around a message that never had one. Clearing -fx-background-color takes both, because
+    // modena paints them from that one property.
+    // Its padding is left alone on purpose: modena gives a scroll pane the same 0.833em it gives
+    // the content of a dialog pane, so keeping it puts the text back on the pixel it was on and a
+    // short message opens exactly the dialog it opened before.
+    // Do not reach for -fx-background here, tempting as it looks: modena derives the text colour
+    // from it, with -fx-text-background-color: ladder(-fx-background, -fx-light-text-color 45%,
+    // -fx-dark-text-color 46%, ...). Setting it to transparent puts the ladder at the dark end and
+    // every label inside the scroll pane turns white on white. The viewport keeps painting the
+    // untouched -fx-background, which is the colour the dialog pane itself uses, so leaving it
+    // alone costs nothing.
+    scroll.setStyle("-fx-background-color: transparent;");
+    return scroll;
+  }
 
   @Override
   public NotificationManager getNotificationManager() {

--- a/ganttproject/src/test/java/net/sourceforge/ganttproject/AlertContentSizeTest.kt
+++ b/ganttproject/src/test/java/net/sourceforge/ganttproject/AlertContentSizeTest.kt
@@ -1,0 +1,128 @@
+/*
+GanttProject is an opensource project management tool. License: GPL3
+Copyright (C) 2026 BarD Software s.r.o, GanttProject team
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 3
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package net.sourceforge.ganttproject
+
+import com.sandec.mdfx.MarkdownView
+import javafx.scene.Node
+import javafx.scene.Scene
+import javafx.scene.control.ButtonType
+import javafx.scene.control.DialogPane
+import javafx.scene.control.ScrollPane
+import javafx.stage.Screen
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.javafx.JavaFx
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * showOptionDialog puts a MarkdownView into the dialog pane when the message is HTML or Markdown.
+ * A MarkdownView is a VBox that asks for as much width as its longest paragraph needs, and
+ * DialogPane takes the preferred size of its content as its own, so a long message used to make
+ * the dialog as wide as the screen and taller than the screen, with the buttons below the bottom
+ * edge.
+ */
+class AlertContentSizeTest {
+  /** MAX_CONTENT_WIDTH in UIFacadeImpl. */
+  private val maxContentWidth = 720.0
+
+  /** The one HTML message the application shows today, from help.recover.autosaveInfo. */
+  private val shortMessage =
+    "**Name:** plan.gan,\n**Modified on:** Sun Sep 06 20:41:12 UTC 2026\n**Size:** 218861\n\nRecover this file?"
+  private val longLine = "The reader stopped at line 17: the attribute \"duration\" of the task " +
+    "holds the value -1, but a duration is expected to be a positive whole number of days. "
+  private val longMessage = longLine.repeat(40)
+
+  /** Lays out a dialog pane the way the toolkit would, without opening a window. */
+  private fun pane(content: Node): DialogPane =
+    DialogPane().also {
+      it.content = content
+      it.buttonTypes.add(ButtonType.OK)
+      Scene(it)
+      it.applyCss()
+      it.layout()
+    }
+
+  /**
+   * The content node as showOptionDialog built it before the bounds were put on it. The text block
+   * it uses there has all of its indentation stripped as incidental, so what reaches MarkdownView
+   * is the message and one trailing newline, and nothing else.
+   */
+  private fun bareMarkdownView(message: String) = MarkdownView(message + "\n")
+
+  @Test
+  fun `a long formatted message does not stretch the dialog sideways`() = runBlocking {
+    withContext(Dispatchers.JavaFx) {
+      val content = pane(UIFacadeImpl.createFormattedContent(longMessage)).content
+      val unbounded = bareMarkdownView(longMessage).prefWidth(-1.0)
+      assertTrue(
+        content.prefWidth(-1.0) <= maxContentWidth,
+        "the message asks for ${unbounded.toInt()} px and the dialog offers " +
+          "${content.prefWidth(-1.0).toInt()} px of it, more than the " +
+          "${maxContentWidth.toInt()} px a message is meant to be laid out in"
+      )
+    }
+  }
+
+  @Test
+  fun `a long formatted message does not stretch the dialog past the screen`() = runBlocking {
+    withContext(Dispatchers.JavaFx) {
+      val allowed = Screen.getPrimary().visualBounds.height * 0.6
+      val content = pane(UIFacadeImpl.createFormattedContent(longMessage)).content
+      assertTrue(
+        content.prefHeight(maxContentWidth) <= allowed,
+        "the dialog asks for ${content.prefHeight(maxContentWidth).toInt()} px of height on a " +
+          "screen of ${Screen.getPrimary().visualBounds.height.toInt()} px, so the buttons below " +
+          "it are pushed off the bottom edge"
+      )
+    }
+  }
+
+  @Test
+  fun `a long formatted message keeps growing behind a scroll bar`() = runBlocking {
+    withContext(Dispatchers.JavaFx) {
+      val once = pane(UIFacadeImpl.createFormattedContent(longMessage)).content
+      val fourTimes = pane(UIFacadeImpl.createFormattedContent(longMessage.repeat(4))).content
+      assertEquals(
+        once.prefHeight(maxContentWidth), fourTimes.prefHeight(maxContentWidth), 0.5,
+        "a message four times as long makes the dialog taller, so the height it may take is not " +
+          "bounded at all"
+      )
+      assertTrue(once is ScrollPane, "the message that does not fit cannot be scrolled to")
+    }
+  }
+
+  @Test
+  fun `a short formatted message keeps the dialog it had`() = runBlocking {
+    withContext(Dispatchers.JavaFx) {
+      val today = pane(bareMarkdownView(shortMessage))
+      val bounded = pane(UIFacadeImpl.createFormattedContent(shortMessage))
+      assertEquals(
+        today.prefWidth(-1.0), bounded.prefWidth(-1.0), 0.5,
+        "a short message no longer opens a dialog of the width it used to have"
+      )
+      assertEquals(
+        today.prefHeight(today.prefWidth(-1.0)), bounded.prefHeight(bounded.prefWidth(-1.0)), 0.5,
+        "a short message no longer opens a dialog of the height it used to have"
+      )
+    }
+  }
+}


### PR DESCRIPTION
`UIFacadeImpl.showOptionDialog` knows two message formats besides plain text, `HTML_MESSAGE_FORMAT` and `MARKDOWN_MESSAGE_FORMAT` (`UIFacade.java:82-83`). Both take a different route from plain text: instead of `setContentText` they put a `MarkdownView` straight into the dialog pane (`UIFacadeImpl.java:302-309`).

A `MarkdownView` is a `VBox`, and a `VBox` asks for as much width as its widest child needs. `DialogPane` in turn takes the preferred size of its content as its own. Nothing bounds either dimension, so a long message makes the dialog as wide as the screen and taller than the screen, and the buttons go with it.

Measured on a 1024x768 screen with a 2611 character HTML message, an error list of the kind a failing document reader would produce:

```
STAGE   x=0 y=63  W=1024 H=519
PANE    W=1024 H=826  prefW=1633
CONTENT MarkdownView W=1024 H=710  prefW=1633  prefH=1655
BUTTON "Restore" x=737..824 y=853..879   on screen = NO
BUTTON "Skip"    x=833..918 y=854..879   on screen = NO
BUTTON "Cancel"  x=928..1013 y=854..879  on screen = NO
```

The dialog pane asks for 1633px of width, is clamped to the screen, and all three buttons sit at y=853..879 — below the bottom edge of a 768px screen. The dialog can then only be dismissed with Escape, which picks the cancel action whatever the user meant. The text is cut off as well: the message is 710px tall inside a 519px window.

## What this changes

The formatted message goes into a scroll pane that bounds the preferred size in both directions:

* width at `MAX_CONTENT_WIDTH = 720`, twice the 360px that `DialogPane.createContentLabel` hard-codes for a plain text message. A formatted message may carry tables and code blocks that do not wrap, so it gets more room than plain text, but not the whole screen. It is a fixed number and not a share of the screen, because how wide a column may be before it becomes hard to read does not depend on the monitor.
* height at 60% of the screen height. This one does depend on the monitor: what is left over has to hold the header and the buttons.

The bounds sit on the **preferred** size and not on the maximum, because the preferred size is the only one `DialogPane` ever asks the content for.

The same message now measures:

```
STAGE   x=152 y=56  W=720 H=541
PANE    W=720 H=541  prefW=720
CONTENT W=720 H=425
SCROLL  content 995px in a 403px viewport, scrollable = YES
BUTTON "Restore" x=585..672 y=561..587  on screen = YES
BUTTON "Skip"    x=681..766 y=562..587  on screen = YES
BUTTON "Cancel"  x=776..861 y=562..587  on screen = YES
```

## A short message is untouched

This is the part worth checking, because a width correction of this kind can quietly change every dialog in the application.

`HTML_MESSAGE_FORMAT` has exactly one call site today, `HelpMenu.java:153`, the question that offers to restore an autosaved document. `MARKDOWN_MESSAGE_FORMAT` has none. That one message must keep the dialog it has, and it does:

|  | before | after |
|---|---|---|
| stage | x=316 y=157 392x238 | x=316 y=157 392x238 |
| dialog pane | 392x238 | 392x238 |
| content | 392x122 | 392x122 |
| buttons | 421..508 / 517..602 / 612..697 | identical |
| scroll bar | — | none |

A screenshot of the two dialogs differs in **0 of 93296 pixels**.

The reason it survives is worth stating, because the obvious version of this change does not: modena gives a `ScrollPane` the same `0.833em` of padding it gives the content of a `DialogPane`. Zeroing the scroll pane's padding — which looks like the tidy thing to do — makes every short formatted dialog 22px narrower. Leaving the padding alone puts the text back on the pixel it was on.

Only `-fx-background-color` is cleared, which takes modena's border and background box with it. `-fx-background` is deliberately not touched: modena derives the text colour from it through `-fx-text-background-color: ladder(-fx-background, ...)`, so setting it to transparent turns every label inside the scroll pane white on white.

## Tests

`AlertContentSizeTest`, four cases:

* a long message does not stretch the dialog sideways
* a long message does not stretch the dialog past the screen
* a long message keeps growing behind a scroll bar (four times the text gives the same height)
* **a short message keeps the dialog it had** — the guard, which compares against a bare `MarkdownView` built the way the code built it before

All four were run against the unfixed code first. The three defect cases fail there and the guard passes, which is what a guard is for. The guard was then made to fail on purpose by tightening the width bound to 200px, to check it can fail at all.

Whole suite: 375 tests before, 382 after, 0 failures.

## Note on #2833

#2833 does the matching thing for the plain text branch of the same method. The two touch different branches of the same `if`, so they do not conflict in behaviour, but they share **one line**: `MAX_CONTENT_HEIGHT_RATIO = 0.6`. Whichever lands second should drop that one declaration and use the other's. This PR stands on its own against `master` and does not depend on #2833.